### PR TITLE
fix: agregar campo Cloro en mapeos de FisicoQuimicoService

### DIFF
--- a/Aplicacion/Services/FisicoQuimicoService.cs
+++ b/Aplicacion/Services/FisicoQuimicoService.cs
@@ -32,6 +32,7 @@ namespace Aplicacion.Services
                 Calcio = fq.Calcio,
                 Magnesio = fq.Magnesio,
                 Dbo5 = fq.Dbo5,
+                Cloro = fq.Cloro,
                 MuestraId = fq.MuestraId
             }).ToList();
         }
@@ -56,6 +57,7 @@ namespace Aplicacion.Services
                 Calcio = entity.Calcio,
                 Magnesio = entity.Magnesio,
                 Dbo5 = entity.Dbo5,
+                Cloro = entity.Cloro,
                 MuestraId = entity.MuestraId
             };
         }
@@ -77,6 +79,7 @@ namespace Aplicacion.Services
                 Calcio = dto.Calcio,
                 Magnesio = dto.Magnesio,
                 Dbo5 = dto.Dbo5,
+                Cloro = dto.Cloro,
                 MuestraId = dto.MuestraId
             };
 
@@ -98,6 +101,7 @@ namespace Aplicacion.Services
                 Calcio = created.Calcio,
                 Magnesio = created.Magnesio,
                 Dbo5 = created.Dbo5,
+                Cloro = created.Cloro,
                 MuestraId = created.MuestraId
             };
         }
@@ -118,6 +122,7 @@ namespace Aplicacion.Services
             entity.Calcio = dto.Calcio;
             entity.Magnesio = dto.Magnesio;
             entity.Dbo5 = dto.Dbo5;
+            entity.Cloro = dto.Cloro;
 
             await _repo.UpdateAsync(entity);
         }


### PR DESCRIPTION
## Descripción\nFix del bug donde el campo `Cloro` no aparecía en la vista de FisicoQuímico al crear una planilla diaria.\n\n## Causa\nEl campo `Cloro` existía en la entidad `FisicoQuimico` y en el DTO, pero no se mapeaba en `FisicoQuimicoService`.\n\n## Cambios\n- `GetAllAsync`: agregado `Cloro = fq.Cloro`\n- `GetByIdAsync`: agregado `Cloro = entity.Cloro`\n- `CreateAsync` (entity): agregado `Cloro = dto.Cloro`\n- `CreateAsync` (return): agregado `Cloro = created.Cloro`\n- `UpdateAsync`: agregado `entity.Cloro = dto.Cloro`\n\nCloses #11