### PR TITLE
fix: evitar sobreescritura de muestras nuevas en UpdateLibroEntrada (#34)

### DIFF
--- a/Aplicacion/Services/LibroDeEntradaService.cs
+++ b/Aplicacion/Services/LibroDeEntradaService.cs
@@ -286,7 +286,12 @@ namespace Aplicacion.Services
             // Actualizar y agregar muestras
             foreach (var muestraDto in muestrasDto)
             {
-                var muestraExistente = muestrasActuales.FirstOrDefault(m => m.Id == muestraDto.Id);
+                // Solo buscar existente si el dto tiene un ID real (> 0).
+                // Si Id es 0, es muestra nueva y siempre va al branch de creación,
+                // evitando que varias muestras nuevas se sobreescriban entre sí.
+                var muestraExistente = muestraDto.Id > 0
+                    ? muestrasActuales.FirstOrDefault(m => m.Id == muestraDto.Id)
+                    : null;
 
                 var cliente = await _clienteRepository.GetByIdAsync(muestraDto.ClienteId);
                 if (cliente == null)


### PR DESCRIPTION
## Cambios\n\nFix para issue #34 — Al añadir varias muestras nuevas al editar un LibroEntrada, solo la última era persistida.\n\n## Causa raíz\n\n`muestrasActuales.FirstOrDefault(m => m.Id == muestraDto.Id)` con `muestraDto.Id == 0` matcheaba la primera muestra nueva ya agregada a la lista en memoria (que también tiene `Id=0` antes de persisitir). La segunda muestra nueva sobreescribía a la primera.\n\n## Fix\n\n```csharp\nvar muestraExistente = muestraDto.Id > 0\n    ? muestrasActuales.FirstOrDefault(m => m.Id == muestraDto.Id)\n    : null;\n```\n\nMuestras con `Id=0` siempre van al branch de creación.\n\n## Code Review\n\nRevisado y aprobado por Code Reviewer — sin regressions, lógica de eliminación intacta.