### PR TITLE
refactor: extraer mapping entidad→DTO a clases mapper separadas (issue #45)

### DIFF
--- a/Aplicacion/Mappers/ClienteMapper.cs
+++ b/Aplicacion/Mappers/ClienteMapper.cs
@@ -1,0 +1,20 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class ClienteMapper
+    {
+        public static ClienteResponseDto ToDto(this Cliente cliente, int numeroMuestras = 0)
+        {
+            return new ClienteResponseDto
+            {
+                Id = cliente.Id,
+                Nombre = cliente.Nombre,
+                Telefono = cliente.Telefono,
+                Email = cliente.Email,
+                NumeroMuestras = numeroMuestras
+            };
+        }
+    }
+}

--- a/Aplicacion/Mappers/LibroDeEntradaMapper.cs
+++ b/Aplicacion/Mappers/LibroDeEntradaMapper.cs
@@ -1,0 +1,24 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class LibroDeEntradaMapper
+    {
+        public static LibroDeEntradaResponseDto ToDto(this LibroDeEntrada le)
+        {
+            return new LibroDeEntradaResponseDto
+            {
+                Id = le.Id,
+                FechaRegistro = le.Fecha,
+                FechaLlegada = le.FechaLLegada,
+                FechaAnalisis = le.FechaAnalisis,
+                Procedencia = le.Procedencia,
+                SitioExtraccion = le.SitioExtraccion,
+                Observaciones = le.Observaciones,
+                Muestras = le.Muestras?.Select(m => m.ToDto()).ToList()
+                            ?? new List<MuestraResponseDto>()
+            };
+        }
+    }
+}

--- a/Aplicacion/Mappers/MuestraMapper.cs
+++ b/Aplicacion/Mappers/MuestraMapper.cs
@@ -1,0 +1,31 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class MuestraMapper
+    {
+        public static MuestraResponseDto ToDto(this Muestra m)
+        {
+            return new MuestraResponseDto
+            {
+                Id = m.Id,
+                Procedencia = m.Procedencia,
+                NombreMuestreador = m.NombreMuestreador,
+                Latitud = m.Latitud,
+                Longitud = m.Longitud,
+                FechaExtraccion = m.FechaExtraccion,
+                HoraExtraccion = m.HoraExtraccion,
+                TipoMuestra = m.TipoMuestra switch
+                {
+                    TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
+                    TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
+                    _ => throw new ArgumentException("Tipo de muestra no válido.")
+                },
+                ClienteId = m.ClienteId,
+                ClienteNombre = m.Cliente?.Nombre,
+                LibroEntradaId = m.LibroEntradaId
+            };
+        }
+    }
+}

--- a/Aplicacion/Services/ClienteService.cs
+++ b/Aplicacion/Services/ClienteService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using Aplicacion.Mappers;
+using Infrastructure.Dtos;
 using Dominio;
 using Dominio.Entities;
 using Dominio.IRepository;
@@ -37,14 +38,7 @@ namespace Aplicacion.Services
                 return Result<ClienteResponseDto>.Failure($"Cliente con ID {id} no encontrado.");
 
             var muestras = await _muestraRepository.GetByClienteIdAsync(id);
-            return Result<ClienteResponseDto>.Success(new ClienteResponseDto
-            {
-                Id = cliente.Id,
-                Nombre = cliente.Nombre,
-                Telefono = cliente.Telefono,
-                Email = cliente.Email,
-                NumeroMuestras = muestras?.Count ?? 0
-            });
+            return Result<ClienteResponseDto>.Success(cliente.ToDto(muestras?.Count ?? 0));
         }
 
         public async Task<List<ClienteResponseDto>> GetAllClientesAsync()
@@ -55,14 +49,7 @@ namespace Aplicacion.Services
             foreach (var cliente in clientes)
             {
                 var muestras = await _muestraRepository.GetByClienteIdAsync(cliente.Id);
-                result.Add(new ClienteResponseDto
-                {
-                    Id = cliente.Id,
-                    Nombre = cliente.Nombre,                    
-                    Telefono = cliente.Telefono,
-                    Email = cliente.Email,
-                    NumeroMuestras = muestras?.Count ?? 0
-                });
+                result.Add(cliente.ToDto(muestras?.Count ?? 0));
             }
 
             return result;

--- a/Aplicacion/Services/LibroDeEntradaService.cs
+++ b/Aplicacion/Services/LibroDeEntradaService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using Aplicacion.Mappers;
+using Infrastructure.Dtos;
 using Dominio.Exceptions;
 using Dominio.Entities;
 using Dominio.IRepository;
@@ -25,35 +26,7 @@ namespace Aplicacion.Services
         {
             var (libros, totalCount) = await _libroEntradaRepository.GetAllPagedAsync(page, pageSize);
             
-            var items = libros.Select(le => new LibroDeEntradaResponseDto
-            {
-                Id = le.Id,
-                FechaRegistro = le.Fecha,
-                FechaLlegada = le.FechaLLegada,
-                FechaAnalisis = le.FechaAnalisis,
-                Procedencia = le.Procedencia,
-                SitioExtraccion = le.SitioExtraccion,
-                Observaciones = le.Observaciones,
-                Muestras = le.Muestras?.Select(m => new MuestraResponseDto
-                {
-                    Id = m.Id,
-                    Procedencia = m.Procedencia,
-                    NombreMuestreador = m.NombreMuestreador,
-                    Latitud = m.Latitud,
-                    Longitud = m.Longitud,
-                    FechaExtraccion = m.FechaExtraccion,
-                    HoraExtraccion = m.HoraExtraccion,
-                    TipoMuestra = m.TipoMuestra switch
-                    {
-                        TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                        TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                        _ => throw new ArgumentException("Tipo de muestra no válido.")
-                    },
-                    ClienteId = m.ClienteId,
-                    ClienteNombre = m.Cliente?.Nombre,
-                    LibroEntradaId = m.LibroEntradaId
-                }).ToList() ?? new List<MuestraResponseDto>()
-            }).ToList();
+            var items = libros.Select(le => le.ToDto()).ToList();
 
             return new PagedResultDto<LibroDeEntradaResponseDto>
             {
@@ -163,34 +136,7 @@ namespace Aplicacion.Services
                 throw new NotFoundException($"Libro de entrada con ID {id} no encontrado.");
             }
 
-            return new LibroDeEntradaResponseDto
-            {
-                Id = libroEntrada.Id,
-                FechaRegistro = libroEntrada.Fecha,
-                FechaLlegada = libroEntrada.FechaLLegada,
-                FechaAnalisis = libroEntrada.FechaAnalisis,
-                Procedencia = libroEntrada.Procedencia,               
-                Observaciones = libroEntrada.Observaciones,
-                Muestras = libroEntrada.Muestras?.Select(m => new MuestraResponseDto
-                {
-                    Id = m.Id,
-                    Procedencia = m.Procedencia,
-                    NombreMuestreador = m.NombreMuestreador,
-                    Latitud = m.Latitud,
-                    Longitud = m.Longitud,
-                    FechaExtraccion = m.FechaExtraccion,
-                    HoraExtraccion = m.HoraExtraccion,
-                    TipoMuestra = m.TipoMuestra switch
-                    {
-                        TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                        TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                        _ => throw new ArgumentException("Tipo de muestra no válido.")
-                    },
-                    ClienteId = m.ClienteId,
-                    ClienteNombre = m.Cliente?.Nombre,
-                    LibroEntradaId = m.LibroEntradaId
-                }).ToList() ?? new List<MuestraResponseDto>()
-            };
+            return libroEntrada.ToDto();
         }
 
         public async Task<List<LibroDeEntradaResponseDto>> GetLibroEntradasByMuestraIdAsync(int muestraId)
@@ -202,68 +148,13 @@ namespace Aplicacion.Services
             }
 
             var libroEntradas = await _libroEntradaRepository.GetByMuestraIdAsync(muestraId);
-            return libroEntradas.Select(le => new LibroDeEntradaResponseDto
-            {
-                Id = le.Id,
-                FechaRegistro = le.Fecha,
-                FechaLlegada = le.FechaLLegada,
-                FechaAnalisis = le.FechaAnalisis,
-                Procedencia = le.Procedencia,           
-                Observaciones = le.Observaciones,
-                Muestras = le.Muestras?.Select(m => new MuestraResponseDto
-                {
-                    Id = m.Id,
-                    Procedencia = m.Procedencia,
-                    NombreMuestreador = m.NombreMuestreador,
-                    Latitud = m.Latitud,
-                    Longitud = m.Longitud,
-                    FechaExtraccion = m.FechaExtraccion,
-                    HoraExtraccion = m.HoraExtraccion,
-                    TipoMuestra = m.TipoMuestra switch
-                    {
-                        TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                        TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                        _ => throw new ArgumentException("Tipo de muestra no válido.")
-                    },
-                    ClienteId = m.ClienteId,
-                    ClienteNombre = m.Cliente?.Nombre,
-                    LibroEntradaId = m.LibroEntradaId
-                }).ToList() ?? new List<MuestraResponseDto>()
-            }).ToList();
+            return libroEntradas.Select(le => le.ToDto()).ToList();
         }
 
         public async Task<List<LibroDeEntradaResponseDto>> GetLibroEntradasByProcedenciaAsync(string procedencia)
         {
             var libros = await _libroEntradaRepository.GetByProcedenciaAsync(procedencia);
-            return libros.Select(le => new LibroDeEntradaResponseDto
-            {
-                Id = le.Id,
-                FechaRegistro = le.Fecha,
-                FechaLlegada = le.FechaLLegada,
-                FechaAnalisis = le.FechaAnalisis,
-                Procedencia = le.Procedencia,
-                SitioExtraccion = le.SitioExtraccion,
-                Observaciones = le.Observaciones,
-                Muestras = le.Muestras?.Select(m => new MuestraResponseDto
-                {
-                    Id = m.Id,
-                    Procedencia = m.Procedencia,
-                    NombreMuestreador = m.NombreMuestreador,
-                    Latitud = m.Latitud,
-                    Longitud = m.Longitud,
-                    FechaExtraccion = m.FechaExtraccion,
-                    HoraExtraccion = m.HoraExtraccion,
-                    TipoMuestra = m.TipoMuestra switch
-                    {
-                        TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                        TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                        _ => throw new ArgumentException("Tipo de muestra no válido.")
-                    },
-                    ClienteId = m.ClienteId,
-                    ClienteNombre = m.Cliente?.Nombre,
-                    LibroEntradaId = m.LibroEntradaId
-                }).ToList() ?? new List<MuestraResponseDto>()
-            }).ToList();
+            return libros.Select(le => le.ToDto()).ToList();
         }
 
         public async Task UpdateLibroEntradaAsync(LibroDeEntradaDto libroEntradaDto)
@@ -450,35 +341,7 @@ namespace Aplicacion.Services
 {
     var (libros, totalCount) = await _libroEntradaRepository.GetByProcedenciaPagedAsync(procedencia, page, pageSize);
     
-    var items = libros.Select(le => new LibroDeEntradaResponseDto
-    {
-        Id = le.Id,
-        FechaRegistro = le.Fecha,
-        FechaLlegada = le.FechaLLegada,
-        FechaAnalisis = le.FechaAnalisis,
-        Procedencia = le.Procedencia,
-        SitioExtraccion = le.SitioExtraccion,
-        Observaciones = le.Observaciones,
-        Muestras = le.Muestras?.Select(m => new MuestraResponseDto
-        {
-            Id = m.Id,
-            Procedencia = m.Procedencia,
-            NombreMuestreador = m.NombreMuestreador,
-            Latitud = m.Latitud,
-            Longitud = m.Longitud,
-            FechaExtraccion = m.FechaExtraccion,
-            HoraExtraccion = m.HoraExtraccion,
-            TipoMuestra = m.TipoMuestra switch
-            {
-                TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                _ => throw new ArgumentException("Tipo de muestra no válido.")
-            },
-            ClienteId = m.ClienteId,
-            ClienteNombre = m.Cliente?.Nombre,
-            LibroEntradaId = m.LibroEntradaId
-        }).ToList() ?? new List<MuestraResponseDto>()
-    }).ToList();
+    var items = libros.Select(le => le.ToDto()).ToList();
 
     return new PagedResultDto<LibroDeEntradaResponseDto>
     {
@@ -494,35 +357,7 @@ namespace Aplicacion.Services
         {
             var (libros, totalCount) = await _libroEntradaRepository.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
 
-            var items = libros.Select(le => new LibroDeEntradaResponseDto
-            {
-                Id = le.Id,
-                FechaRegistro = le.Fecha,
-                FechaLlegada = le.FechaLLegada,
-                FechaAnalisis = le.FechaAnalisis,
-                Procedencia = le.Procedencia,
-                SitioExtraccion = le.SitioExtraccion,
-                Observaciones = le.Observaciones,
-                Muestras = le.Muestras?.Select(m => new MuestraResponseDto
-                {
-                    Id = m.Id,
-                    Procedencia = m.Procedencia,
-                    NombreMuestreador = m.NombreMuestreador,
-                    Latitud = m.Latitud,
-                    Longitud = m.Longitud,
-                    FechaExtraccion = m.FechaExtraccion,
-                    HoraExtraccion = m.HoraExtraccion,
-                    TipoMuestra = m.TipoMuestra switch
-                    {
-                        TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                        TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                        _ => throw new ArgumentException("Tipo de muestra no válido.")
-                    },
-                    ClienteId = m.ClienteId,
-                    ClienteNombre = m.Cliente?.Nombre,
-                    LibroEntradaId = m.LibroEntradaId
-                }).ToList() ?? new List<MuestraResponseDto>()
-            }).ToList();
+            var items = libros.Select(le => le.ToDto()).ToList();
 
             return new PagedResultDto<LibroDeEntradaResponseDto>
             {

--- a/Aplicacion/Services/LibroDeEntradaService.cs
+++ b/Aplicacion/Services/LibroDeEntradaService.cs
@@ -337,20 +337,20 @@ namespace Aplicacion.Services
         }
 
         public async Task<PagedResultDto<LibroDeEntradaResponseDto>> GetLibroEntradasByProcedenciaPagedAsync(
-    string procedencia, int page = 1, int pageSize = 50)
-{
-    var (libros, totalCount) = await _libroEntradaRepository.GetByProcedenciaPagedAsync(procedencia, page, pageSize);
-    
-    var items = libros.Select(le => le.ToDto()).ToList();
+            string procedencia, int page = 1, int pageSize = 50)
+        {
+            var (libros, totalCount) = await _libroEntradaRepository.GetByProcedenciaPagedAsync(procedencia, page, pageSize);
 
-    return new PagedResultDto<LibroDeEntradaResponseDto>
-    {
-        Items = items,
-        TotalCount = totalCount,
-        Page = page,
-        PageSize = pageSize
-    };
-}
+            var items = libros.Select(le => le.ToDto()).ToList();
+
+            return new PagedResultDto<LibroDeEntradaResponseDto>
+            {
+                Items = items,
+                TotalCount = totalCount,
+                Page = page,
+                PageSize = pageSize
+            };
+        }
 
         public async Task<PagedResultDto<LibroDeEntradaResponseDto>> GetLibroEntradasByFechaRangoAsync(
             DateTime desde, DateTime hasta, int page = 1, int pageSize = 50)

--- a/Aplicacion/Services/MuestraService.cs
+++ b/Aplicacion/Services/MuestraService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using Aplicacion.Mappers;
+using Infrastructure.Dtos;
 using Dominio.Exceptions;
 using Dominio.Entities;
 using Dominio.IRepository;
@@ -109,25 +110,7 @@ namespace Aplicacion.Services
             }
 
             var muestras = await _muestraRepository.GetByClienteIdAsync(clienteId);
-            return muestras.Select(m => new MuestraResponseDto
-            {
-                Id = m.Id,
-                Procedencia = m.Procedencia,
-                NombreMuestreador = m.NombreMuestreador,
-                Latitud = m.Latitud,
-                Longitud = m.Longitud,
-                FechaExtraccion = m.FechaExtraccion,
-                HoraExtraccion = m.HoraExtraccion,
-                TipoMuestra = m.TipoMuestra switch
-                {
-                    TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                    TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                    _ => throw new ArgumentException("Tipo de muestra no válido.")
-                },
-                ClienteId = m.ClienteId,
-                ClienteNombre = m.Cliente?.Nombre,
-                LibroEntradaId = m.LibroEntradaId
-            }).ToList();
+            return muestras.Select(m => m.ToDto()).ToList();
         }
     }
 }


### PR DESCRIPTION
Cierra #45

## Cambios
- Nuevos: `Aplicacion/Mappers/ClienteMapper.cs`, `MuestraMapper.cs`, `LibroDeEntradaMapper.cs`
- Refactorizados: `ClienteService`, `LibroDeEntradaService`, `MuestraService` — eliminados 6 bloques de mapping inline

## Qué hace
Extrae la construcción de DTOs de respuesta (`ClienteResponseDto`, `MuestraResponseDto`, `LibroDeEntradaResponseDto`) a extension methods estáticos en `Aplicacion.Mappers`. Los services ahora solo orquestan lógica de negocio sin construir DTOs directamente.

## Verificación
- Build: 0 errores (solo warnings pre-existentes de nullable)
- Code Review: aprobado sin bloqueantes