### PR TITLE
refactor: completar extracción de mappers entidad→DTO en todos los services

### DIFF
--- a/Aplicacion/Mappers/BacteriologicoMapper.cs
+++ b/Aplicacion/Mappers/BacteriologicoMapper.cs
@@ -1,0 +1,26 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class BacteriologicoMapper
+    {
+        public static BacteriologicoDto ToDto(this Bacteriologico b)
+        {
+            return new BacteriologicoDto
+            {
+                Id = b.Id,
+                Fecha = b.Fecha,
+                FechaLLegada = b.FechaLLegada,
+                FechaAnalisis = b.FechaAnalisis,
+                Procedencia = b.Procedencia,
+                ColiformesNmp = b.ColiformesNmp,
+                ColiformesFecalesNmp = b.ColiformesFecalesNmp,
+                ColoniasAgar = b.ColoniasAgar,
+                ColiFecalesUfc = b.ColiFecalesUfc,
+                Observaciones = b.Observaciones,
+                MuestraId = b.MuestraId
+            };
+        }
+    }
+}

--- a/Aplicacion/Mappers/FisicoQuimicoMapper.cs
+++ b/Aplicacion/Mappers/FisicoQuimicoMapper.cs
@@ -1,0 +1,31 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class FisicoQuimicoMapper
+    {
+        public static FisicoQuimicoDto ToDto(this FisicoQuimico fq)
+        {
+            return new FisicoQuimicoDto
+            {
+                Id = fq.Id,
+                Fecha = fq.Fecha,
+                FechaLLegada = fq.FechaLLegada,
+                FechaAnalisis = fq.FechaAnalisis,
+                Procedencia = fq.Procedencia,
+                Ph = fq.Ph,
+                Turbidez = fq.Turbidez,
+                Alcalinidad = fq.Alcalinidad,
+                Dureza = fq.Dureza,
+                Nitritos = fq.Nitritos,
+                Cloruros = fq.Cloruros,
+                Calcio = fq.Calcio,
+                Magnesio = fq.Magnesio,
+                Dbo5 = fq.Dbo5,
+                Cloro = fq.Cloro,
+                MuestraId = fq.MuestraId
+            };
+        }
+    }
+}

--- a/Aplicacion/Mappers/PlanillaDiariaMapper.cs
+++ b/Aplicacion/Mappers/PlanillaDiariaMapper.cs
@@ -11,7 +11,7 @@ namespace Aplicacion.Mappers
             PuntoMuestreo.Decantada   => PuntoMuestreoDto.Decantada,
             PuntoMuestreo.Filtrada    => PuntoMuestreoDto.Filtrada,
             PuntoMuestreo.Consumo     => PuntoMuestreoDto.Consumo,
-            _ => PuntoMuestreoDto.AguaNatural
+            _ => throw new ArgumentException($"PuntoMuestreo '{punto}' no tiene mapeo DTO.")
         };
 
         public static EnsayoJarrasDto? ToDto(this EnsayoJarras? e)

--- a/Aplicacion/Mappers/PlanillaDiariaMapper.cs
+++ b/Aplicacion/Mappers/PlanillaDiariaMapper.cs
@@ -1,0 +1,66 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class PlanillaDiariaMapper
+    {
+        public static PuntoMuestreoDto ToDto(this PuntoMuestreo punto) => punto switch
+        {
+            PuntoMuestreo.AguaNatural => PuntoMuestreoDto.AguaNatural,
+            PuntoMuestreo.Decantada   => PuntoMuestreoDto.Decantada,
+            PuntoMuestreo.Filtrada    => PuntoMuestreoDto.Filtrada,
+            PuntoMuestreo.Consumo     => PuntoMuestreoDto.Consumo,
+            _ => PuntoMuestreoDto.AguaNatural
+        };
+
+        public static EnsayoJarrasDto? ToDto(this EnsayoJarras? e)
+        {
+            if (e == null) return null;
+            return new EnsayoJarrasDto
+            {
+                Id = e.Id,
+                Dosis1 = e.Dosis1,
+                Dosis2 = e.Dosis2,
+                Dosis3 = e.Dosis3,
+                Dosis4 = e.Dosis4,
+                Dosis5 = e.Dosis5,
+                DosisSeleccionada = e.DosisSeleccionada,
+                PreCal = e.PreCal,
+                PostCal = e.PostCal,
+                UnidadMedida = e.UnidadMedida
+            };
+        }
+
+        public static PlanillaDiariaResponseDto ToDto(this PlanillaDiaria p)
+        {
+            var analisis = p.LibroEntrada?.Muestras?
+                .Where(m => m.PuntoMuestreo.HasValue && m.FisicoQuimico != null)
+                .Select(m => new AnalisisPuntoDto
+                {
+                    PuntoMuestreo = m.PuntoMuestreo!.Value.ToDto(),
+                    Ph = m.FisicoQuimico!.Ph,
+                    Turbidez = m.FisicoQuimico.Turbidez,
+                    Alcalinidad = m.FisicoQuimico.Alcalinidad,
+                    Dureza = m.FisicoQuimico.Dureza,
+                    Nitritos = m.FisicoQuimico.Nitritos,
+                    Cloruros = m.FisicoQuimico.Cloruros,
+                    Calcio = m.FisicoQuimico.Calcio,
+                    Magnesio = m.FisicoQuimico.Magnesio,
+                    Dbo5 = m.FisicoQuimico.Dbo5,
+                    Cloro = m.FisicoQuimico.Cloro,
+                }).ToList() ?? new List<AnalisisPuntoDto>();
+
+            return new PlanillaDiariaResponseDto
+            {
+                Id = p.Id,
+                Fecha = p.Fecha,
+                Operador = p.Operador,
+                Observaciones = p.Observaciones,
+                LibroEntradaId = p.LibroEntradaId,
+                AnalisisPorPunto = analisis,
+                EnsayoJarras = p.EnsayoJarras.ToDto()
+            };
+        }
+    }
+}

--- a/Aplicacion/Mappers/ReporteMapper.cs
+++ b/Aplicacion/Mappers/ReporteMapper.cs
@@ -1,0 +1,47 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class ReporteMapper
+    {
+        public static ReporteMuestraDto ToReporteMuestraDto(this Muestra m)
+        {
+            return new ReporteMuestraDto
+            {
+                MuestraId = m.Id,
+                Procedencia = m.Procedencia,
+                SitioExtraccion = m.Procedencia,
+                NombreMuestreador = m.NombreMuestreador,
+                TipoMuestra = m.TipoMuestra switch
+                {
+                    TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
+                    TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
+                    _ => throw new ArgumentException("Tipo de muestra no válido.")
+                },
+                ClienteId = m.ClienteId,
+                ClienteNombre = m.Cliente?.Nombre,
+                Bacteriologia = m.Bacteriologia?.ToDto(),
+                FisicoQuimico = m.FisicoQuimico?.ToDto()
+            };
+        }
+
+        public static ReporteLibroDto ToReporteLibroDto(this LibroDeEntrada libro)
+        {
+            var reporte = new ReporteLibroDto
+            {
+                LibroId = libro.Id,
+                FechaRegistro = libro.Fecha,
+                FechaLlegada = libro.FechaLLegada,
+                FechaAnalisis = libro.FechaAnalisis,
+                Procedencia = libro.Procedencia,
+                Observaciones = libro.Observaciones
+            };
+
+            if (libro.Muestras != null)
+                reporte.Muestras.AddRange(libro.Muestras.Select(m => m.ToReporteMuestraDto()));
+
+            return reporte;
+        }
+    }
+}

--- a/Aplicacion/Services/BacteriologicoService.cs
+++ b/Aplicacion/Services/BacteriologicoService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using Aplicacion.Mappers;
+using Infrastructure.Dtos;
 using Dominio.IRepository;
 using Dominio.Entities;
 using Dominio.Exceptions;
@@ -17,7 +18,7 @@ namespace Aplicacion.Services
         public async Task<List<BacteriologicoDto>> GetAllAsync()
         {
             var entities = await _repo.GetAllAsync();
-            return entities.Select(MapToDto).ToList();
+            return entities.Select(b => b.ToDto()).ToList();
         }
 
         public async Task<PagedResultDto<BacteriologicoDto>> GetAllPagedAsync(int page, int pageSize)
@@ -25,7 +26,7 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetAllPagedAsync(page, pageSize);
             return new PagedResultDto<BacteriologicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(b => b.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -37,7 +38,7 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
             return new PagedResultDto<BacteriologicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(b => b.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -49,33 +50,18 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetByClienteIdPagedAsync(clienteId, page, pageSize);
             return new PagedResultDto<BacteriologicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(b => b.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
             };
         }
 
-        private static BacteriologicoDto MapToDto(Bacteriologico b) => new BacteriologicoDto
-        {
-            Id = b.Id,
-            Fecha = b.Fecha,
-            FechaLLegada = b.FechaLLegada,
-            FechaAnalisis = b.FechaAnalisis,
-            Procedencia = b.Procedencia,
-            ColiformesNmp = b.ColiformesNmp,
-            ColiformesFecalesNmp = b.ColiformesFecalesNmp,
-            ColoniasAgar = b.ColoniasAgar,
-            ColiFecalesUfc = b.ColiFecalesUfc,
-            Observaciones = b.Observaciones,
-            MuestraId = b.MuestraId
-        };
-
         public async Task<BacteriologicoDto?> GetByIdAsync(int id)
         {
             var entity = await _repo.GetByIdAsync(id);
             if (entity == null) return null;
-            return MapToDto(entity);
+            return entity.ToDto();
         }
 
         public async Task<BacteriologicoDto> CreateAsync(BacteriologicoDto dto)
@@ -95,7 +81,7 @@ namespace Aplicacion.Services
             };
 
             var created = await _repo.AddAsync(entity);
-            return MapToDto(created);
+            return created.ToDto();
         }
 
         public async Task UpdateAsync(BacteriologicoDto dto)

--- a/Aplicacion/Services/FisicoQuimicoService.cs
+++ b/Aplicacion/Services/FisicoQuimicoService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using Aplicacion.Mappers;
+using Infrastructure.Dtos;
 using Dominio.IRepository;
 using Dominio.Entities;
 using Dominio.Exceptions;
@@ -17,7 +18,7 @@ namespace Aplicacion.Services
         public async Task<List<FisicoQuimicoDto>> GetAllAsync()
         {
             var entities = await _repo.GetAllAsync();
-            return entities.Select(MapToDto).ToList();
+            return entities.Select(fq => fq.ToDto()).ToList();
         }
 
         public async Task<PagedResultDto<FisicoQuimicoDto>> GetAllPagedAsync(int page, int pageSize)
@@ -25,7 +26,7 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetAllPagedAsync(page, pageSize);
             return new PagedResultDto<FisicoQuimicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(fq => fq.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -37,7 +38,7 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
             return new PagedResultDto<FisicoQuimicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(fq => fq.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -49,38 +50,18 @@ namespace Aplicacion.Services
             var (items, totalCount) = await _repo.GetByClienteIdPagedAsync(clienteId, page, pageSize);
             return new PagedResultDto<FisicoQuimicoDto>
             {
-                Items = items.Select(MapToDto).ToList(),
+                Items = items.Select(fq => fq.ToDto()).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
             };
         }
 
-        private static FisicoQuimicoDto MapToDto(FisicoQuimico fq) => new FisicoQuimicoDto
-        {
-            Id = fq.Id,
-            Fecha = fq.Fecha,
-            FechaLLegada = fq.FechaLLegada,
-            FechaAnalisis = fq.FechaAnalisis,
-            Procedencia = fq.Procedencia,
-            Ph = fq.Ph,
-            Turbidez = fq.Turbidez,
-            Alcalinidad = fq.Alcalinidad,
-            Dureza = fq.Dureza,
-            Nitritos = fq.Nitritos,
-            Cloruros = fq.Cloruros,
-            Calcio = fq.Calcio,
-            Magnesio = fq.Magnesio,
-            Dbo5 = fq.Dbo5,
-            Cloro = fq.Cloro,
-            MuestraId = fq.MuestraId
-        };
-
         public async Task<FisicoQuimicoDto?> GetByIdAsync(int id)
         {
             var entity = await _repo.GetByIdAsync(id);
             if (entity == null) return null;
-            return MapToDto(entity);
+            return entity.ToDto();
         }
 
         public async Task<FisicoQuimicoDto> CreateAsync(FisicoQuimicoDto dto)
@@ -105,7 +86,7 @@ namespace Aplicacion.Services
             };
 
             var created = await _repo.AddAsync(entity);
-            return MapToDto(created);
+            return created.ToDto();
         }
 
         public async Task UpdateAsync(FisicoQuimicoEditDto dto)

--- a/Aplicacion/Services/PlanillaDiariaService.cs
+++ b/Aplicacion/Services/PlanillaDiariaService.cs
@@ -1,3 +1,4 @@
+using Aplicacion.Mappers;
 using Infrastructure.Dtos;
 using Dominio.Exceptions;
 using Dominio.Entities;
@@ -26,7 +27,7 @@ namespace Aplicacion.Services
             var (items, total) = await _planillaRepo.GetAllPagedAsync(page, pageSize);
             return new PagedResultDto<PlanillaDiariaResponseDto>
             {
-                Items = items.Select(MapToResponseDto).ToList(),
+                Items = items.Select(p => p.ToDto()).ToList(),
                 TotalCount = total,
                 Page = page,
                 PageSize = pageSize
@@ -37,14 +38,14 @@ namespace Aplicacion.Services
         {
             var planilla = await _planillaRepo.GetByIdAsync(id)
                 ?? throw new NotFoundException($"Planilla con ID {id} no encontrada.");
-            return MapToResponseDto(planilla);
+            return planilla.ToDto();
         }
 
         public async Task<PlanillaDiariaResponseDto> GetByFechaAsync(DateTime fecha)
         {
             var planilla = await _planillaRepo.GetByFechaAsync(fecha)
                 ?? throw new NotFoundException($"No existe planilla para la fecha {fecha:yyyy-MM-dd}.");
-            return MapToResponseDto(planilla);
+            return planilla.ToDto();
         }
 
         public async Task<PagedResultDto<PlanillaDiariaResponseDto>> GetByFechaRangoAsync(
@@ -53,7 +54,7 @@ namespace Aplicacion.Services
             var (items, total) = await _planillaRepo.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
             return new PagedResultDto<PlanillaDiariaResponseDto>
             {
-                Items = items.Select(MapToResponseDto).ToList(),
+                Items = items.Select(p => p.ToDto()).ToList(),
                 TotalCount = total,
                 Page = page,
                 PageSize = pageSize
@@ -74,8 +75,8 @@ namespace Aplicacion.Services
             if (existente != null)
             {
                 await UpdateAsync(existente.Id, dto);
-                return MapToResponseDto(await _planillaRepo.GetByIdAsync(existente.Id)
-                    ?? throw new Exception("Error al recuperar la planilla actualizada."));
+                return (await _planillaRepo.GetByIdAsync(existente.Id)
+                    ?? throw new Exception("Error al recuperar la planilla actualizada.")).ToDto();
             }
 
             // Crear las muestras con sus análisis fisicoquímicos
@@ -158,8 +159,8 @@ namespace Aplicacion.Services
             };
 
             var creada = await _planillaRepo.AddAsync(planilla);
-            return MapToResponseDto(await _planillaRepo.GetByIdAsync(creada.Id)
-                ?? throw new Exception("Error al recuperar la planilla creada."));
+            return (await _planillaRepo.GetByIdAsync(creada.Id)
+                ?? throw new Exception("Error al recuperar la planilla creada.")).ToDto();
         }
 
         public async Task UpdateAsync(int id, PlanillaDiariaDto dto)
@@ -243,59 +244,5 @@ namespace Aplicacion.Services
             PuntoMuestreoDto.Consumo     => PuntoMuestreo.Consumo,
             _ => throw new ArgumentException("PuntoMuestreo no válido.")
         };
-
-        private static PlanillaDiariaResponseDto MapToResponseDto(PlanillaDiaria p)
-        {
-            var analisis = p.LibroEntrada?.Muestras?
-                .Where(m => m.PuntoMuestreo.HasValue && m.FisicoQuimico != null)
-                .Select(m => new AnalisisPuntoDto
-                {
-                    PuntoMuestreo = m.PuntoMuestreo!.Value switch
-                    {
-                        PuntoMuestreo.AguaNatural => PuntoMuestreoDto.AguaNatural,
-                        PuntoMuestreo.Decantada   => PuntoMuestreoDto.Decantada,
-                        PuntoMuestreo.Filtrada    => PuntoMuestreoDto.Filtrada,
-                        PuntoMuestreo.Consumo     => PuntoMuestreoDto.Consumo,
-                        _ => PuntoMuestreoDto.AguaNatural
-                    },
-                    Ph = m.FisicoQuimico!.Ph,
-                    Turbidez = m.FisicoQuimico.Turbidez,
-                    Alcalinidad = m.FisicoQuimico.Alcalinidad,
-                    Dureza = m.FisicoQuimico.Dureza,
-                    Nitritos = m.FisicoQuimico.Nitritos,
-                    Cloruros = m.FisicoQuimico.Cloruros,
-                    Calcio = m.FisicoQuimico.Calcio,
-                    Magnesio = m.FisicoQuimico.Magnesio,
-                    Dbo5 = m.FisicoQuimico.Dbo5,
-                    Cloro = m.FisicoQuimico.Cloro,
-                }).ToList() ?? new List<AnalisisPuntoDto>();
-
-            EnsayoJarrasDto? ensayo = null;
-            if (p.EnsayoJarras != null)
-                ensayo = new EnsayoJarrasDto
-                {
-                    Id = p.EnsayoJarras.Id,
-                    Dosis1 = p.EnsayoJarras.Dosis1,
-                    Dosis2 = p.EnsayoJarras.Dosis2,
-                    Dosis3 = p.EnsayoJarras.Dosis3,
-                    Dosis4 = p.EnsayoJarras.Dosis4,
-                    Dosis5 = p.EnsayoJarras.Dosis5,
-                    DosisSeleccionada = p.EnsayoJarras.DosisSeleccionada,
-                    PreCal = p.EnsayoJarras.PreCal,
-                    PostCal = p.EnsayoJarras.PostCal,
-                    UnidadMedida = p.EnsayoJarras.UnidadMedida
-                };
-
-            return new PlanillaDiariaResponseDto
-            {
-                Id = p.Id,
-                Fecha = p.Fecha,
-                Operador = p.Operador,
-                Observaciones = p.Observaciones,
-                LibroEntradaId = p.LibroEntradaId,
-                AnalisisPorPunto = analisis,
-                EnsayoJarras = ensayo
-            };
-        }
     }
 }

--- a/Aplicacion/Services/ReporteService.cs
+++ b/Aplicacion/Services/ReporteService.cs
@@ -1,3 +1,4 @@
+using Aplicacion.Mappers;
 using Infrastructure.Dtos;
 using Dominio.IRepository;
 using Dominio.Exceptions;
@@ -23,82 +24,7 @@ namespace Aplicacion.Services
             if (libro == null)
                 throw new NotFoundException($"Libro de entrada con ID {libroId} no encontrado.");
 
-            var reporte = new ReporteLibroDto
-            {
-                LibroId = libro.Id,
-                FechaRegistro = libro.Fecha,
-                FechaLlegada = libro.FechaLLegada,
-                FechaAnalisis = libro.FechaAnalisis,
-                Procedencia = libro.Procedencia,
-                Observaciones = libro.Observaciones
-            };
-
-            if (libro.Muestras != null)
-            {
-                foreach (var muestraCompleta in libro.Muestras)
-                {
-                    var muestraDto = new ReporteMuestraDto
-                    {
-                        MuestraId = muestraCompleta.Id,
-                        Procedencia = muestraCompleta.Procedencia,
-                        SitioExtraccion = muestraCompleta.Procedencia,
-                        NombreMuestreador = muestraCompleta.NombreMuestreador,
-                        TipoMuestra = muestraCompleta.TipoMuestra switch
-                        {
-                            TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                            TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                            _ => throw new ArgumentException("Tipo de muestra no válido.")
-                        },
-                        ClienteId = muestraCompleta.ClienteId,
-                        ClienteNombre = muestraCompleta.Cliente?.Nombre
-                    };
-
-                    // Adjuntar resultados si existen
-                    if (muestraCompleta.Bacteriologia != null)
-                    {
-                        muestraDto.Bacteriologia = new BacteriologicoDto
-                        {
-                            Id = muestraCompleta.Bacteriologia.Id,
-                            Fecha = muestraCompleta.Bacteriologia.Fecha,
-                            FechaLLegada = muestraCompleta.Bacteriologia.FechaLLegada,
-                            FechaAnalisis = muestraCompleta.Bacteriologia.FechaAnalisis,
-                            Procedencia = muestraCompleta.Bacteriologia.Procedencia,
-                            ColiformesNmp = muestraCompleta.Bacteriologia.ColiformesNmp,
-                            ColiformesFecalesNmp = muestraCompleta.Bacteriologia.ColiformesFecalesNmp,
-                            ColoniasAgar = muestraCompleta.Bacteriologia.ColoniasAgar,
-                            ColiFecalesUfc = muestraCompleta.Bacteriologia.ColiFecalesUfc,
-                            Observaciones = muestraCompleta.Bacteriologia.Observaciones,
-                            MuestraId = muestraCompleta.Bacteriologia.MuestraId
-                        };
-                    }
-
-                    if (muestraCompleta.FisicoQuimico != null)
-                    {
-                        muestraDto.FisicoQuimico = new FisicoQuimicoDto
-                        {
-                            Id = muestraCompleta.FisicoQuimico.Id,
-                            Fecha = muestraCompleta.FisicoQuimico.Fecha,
-                            FechaLLegada = muestraCompleta.FisicoQuimico.FechaLLegada,
-                            FechaAnalisis = muestraCompleta.FisicoQuimico.FechaAnalisis,
-                            Procedencia = muestraCompleta.FisicoQuimico.Procedencia,
-                            Ph = muestraCompleta.FisicoQuimico.Ph,
-                            Turbidez = muestraCompleta.FisicoQuimico.Turbidez,
-                            Alcalinidad = muestraCompleta.FisicoQuimico.Alcalinidad,
-                            Dureza = muestraCompleta.FisicoQuimico.Dureza,
-                            Nitritos = muestraCompleta.FisicoQuimico.Nitritos,
-                            Cloruros = muestraCompleta.FisicoQuimico.Cloruros,
-                            Calcio = muestraCompleta.FisicoQuimico.Calcio,
-                            Magnesio = muestraCompleta.FisicoQuimico.Magnesio,
-                            Dbo5 = muestraCompleta.FisicoQuimico.Dbo5,
-                            MuestraId = muestraCompleta.FisicoQuimico.MuestraId
-                        };
-                    }
-
-                    reporte.Muestras.Add(muestraDto);
-                }
-            }
-
-            return reporte;
+            return libro.ToReporteLibroDto();
         }
 
         public async Task<byte[]> GenerarPdfBytesAsync(int libroId)


### PR DESCRIPTION
Complementa #45 — completa la extracción de mappers en los services que quedaron fuera de la primera iteración.

## Archivos nuevos en `Aplicacion/Mappers/`
- `BacteriologicoMapper.cs`
- `FisicoQuimicoMapper.cs`
- `PlanillaDiariaMapper.cs` (incluye mappers de `EnsayoJarras` y `PuntoMuestreo`)
- `ReporteMapper.cs` (compone `BacteriologicoMapper` + `FisicoQuimicoMapper`)

## Services refactorizados
- `BacteriologicoService`: eliminado `private static MapToDto()`, ahora usa `b.ToDto()`
- `FisicoQuimicoService`: eliminado `private static MapToDto()`, ahora usa `fq.ToDto()`
- `PlanillaDiariaService`: eliminado `private static MapToResponseDto()`, ahora usa `p.ToDto()`. Se mantiene `MapPuntoMuestreo()` por ser write-path (DTO→entidad)
- `ReporteService`: reemplazados 50 líneas de construcción inline por `libro.ToReporteLibroDto()`

## Verificación
- Build: 0 errores
- Code Review: aprobado — corregido fallback silencioso en `PuntoMuestreo.ToDto()` (lanza `ArgumentException`)