### PR TITLE
refactor: extraer construcción de entidades a LibroDeEntradaFactory (Factory Method)

### DIFF
--- a/Aplicacion/Factories/LibroDeEntradaFactory.cs
+++ b/Aplicacion/Factories/LibroDeEntradaFactory.cs
@@ -25,7 +25,10 @@ namespace Aplicacion.Factories
                 FechaExtraccion = muestraDto.FechaExtraccion,
                 HoraExtraccion = muestraDto.HoraExtraccion,
                 TipoMuestra = tipoMuestra,
-                ClienteId = muestraDto.ClienteId
+                ClienteId = muestraDto.ClienteId,
+                PuntoMuestreo = muestraDto.PuntoMuestreo.HasValue
+                    ? (PuntoMuestreo)muestraDto.PuntoMuestreo.Value
+                    : null
             };
 
             if (tipoMuestra == TipoMuestra.Bacteriologica)
@@ -69,6 +72,7 @@ namespace Aplicacion.Factories
                 Calcio = string.Empty,
                 Magnesio = string.Empty,
                 Dbo5 = string.Empty,
+                Cloro = string.Empty,
                 Muestra = muestra
             };
 

--- a/Aplicacion/Factories/LibroDeEntradaFactory.cs
+++ b/Aplicacion/Factories/LibroDeEntradaFactory.cs
@@ -1,0 +1,94 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Factories
+{
+    public static class LibroDeEntradaFactory
+    {
+        public static TipoMuestra ParseTipoMuestra(TipoDeMuestraDto tipoDto)
+            => tipoDto switch
+            {
+                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
+                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
+                _ => throw new ArgumentException($"Tipo de muestra no válido: {tipoDto}.")
+            };
+
+        public static Muestra CreateMuestra(MuestraDto muestraDto, LibroDeEntradaDto libroDto, string? procedencia)
+        {
+            var tipoMuestra = ParseTipoMuestra(muestraDto.TipoMuestra);
+            var muestra = new Muestra
+            {
+                Procedencia = procedencia,
+                NombreMuestreador = muestraDto.NombreMuestreador,
+                Latitud = muestraDto.Latitud,
+                Longitud = muestraDto.Longitud,
+                FechaExtraccion = muestraDto.FechaExtraccion,
+                HoraExtraccion = muestraDto.HoraExtraccion,
+                TipoMuestra = tipoMuestra,
+                ClienteId = muestraDto.ClienteId
+            };
+
+            if (tipoMuestra == TipoMuestra.Bacteriologica)
+                muestra.Bacteriologia = CreateBacteriologico(libroDto, muestraDto, muestra);
+            else
+                muestra.FisicoQuimico = CreateFisicoQuimico(libroDto, muestraDto, muestra);
+
+            return muestra;
+        }
+
+        public static Bacteriologico CreateBacteriologico(LibroDeEntradaDto libroDto, MuestraDto muestraDto, Muestra muestra)
+            => new Bacteriologico
+            {
+                Fecha = libroDto.Fecha,
+                FechaAnalisis = libroDto.FechaAnalisis,
+                FechaLLegada = libroDto.FechaLLegada,
+                Procedencia = libroDto.Procedencia,
+                SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
+                ColiformesNmp = string.Empty,
+                ColiformesFecalesNmp = string.Empty,
+                ColoniasAgar = string.Empty,
+                ColiFecalesUfc = string.Empty,
+                Observaciones = string.Empty,
+                Muestra = muestra
+            };
+
+        public static FisicoQuimico CreateFisicoQuimico(LibroDeEntradaDto libroDto, MuestraDto muestraDto, Muestra muestra)
+            => new FisicoQuimico
+            {
+                Fecha = libroDto.Fecha,
+                FechaAnalisis = libroDto.FechaAnalisis,
+                FechaLLegada = libroDto.FechaLLegada,
+                Procedencia = libroDto.Procedencia,
+                SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
+                Ph = string.Empty,
+                Turbidez = string.Empty,
+                Alcalinidad = string.Empty,
+                Dureza = string.Empty,
+                Nitritos = string.Empty,
+                Cloruros = string.Empty,
+                Calcio = string.Empty,
+                Magnesio = string.Empty,
+                Dbo5 = string.Empty,
+                Muestra = muestra
+            };
+
+        public static LibroDeEntrada CreateLibroEntrada(LibroDeEntradaDto dto, List<Muestra> muestras)
+        {
+            var libro = new LibroDeEntrada
+            {
+                Fecha = dto.Fecha,
+                FechaLLegada = dto.FechaLLegada,
+                FechaAnalisis = dto.FechaAnalisis,
+                Procedencia = dto.Procedencia,
+                SitioExtraccion = dto.SitioExtraccion ?? string.Empty,
+                Observaciones = dto.Observaciones,
+                Muestras = muestras
+            };
+
+            foreach (var muestra in muestras)
+                muestra.LibroEntrada = libro;
+
+            return libro;
+        }
+    }
+}

--- a/Aplicacion/Services/LibroDeEntradaService.cs
+++ b/Aplicacion/Services/LibroDeEntradaService.cs
@@ -1,4 +1,5 @@
-﻿using Aplicacion.Mappers;
+﻿using Aplicacion.Factories;
+using Aplicacion.Mappers;
 using Infrastructure.Dtos;
 using Dominio.Exceptions;
 using Dominio.Entities;
@@ -46,85 +47,10 @@ namespace Aplicacion.Services
                 if (cliente == null)
                     throw new NotFoundException($"Cliente con ID {muestraDto.ClienteId} no encontrado.");
 
-                TipoMuestra tipoMuestra = muestraDto.TipoMuestra switch
-                {
-                    TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
-                    TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
-                    _ => throw new ArgumentException("Tipo de muestra no válido.")
-                };
-
-                var muestra = new Muestra
-                {
-                    Procedencia = muestraDto.SitioExtraccion,                   
-                    NombreMuestreador = muestraDto.NombreMuestreador,
-                    Latitud = muestraDto.Latitud,
-                    Longitud = muestraDto.Longitud,
-                    FechaExtraccion = muestraDto.FechaExtraccion,
-                    HoraExtraccion = muestraDto.HoraExtraccion,
-                    TipoMuestra = tipoMuestra,
-                    ClienteId = muestraDto.ClienteId
-                };
-
-
-                // Asociar libro de análisis según tipo
-                if (tipoMuestra == TipoMuestra.Bacteriologica)
-                {
-                    muestra.Bacteriologia = new Bacteriologico
-                    {
-                        Fecha = libroEntradaDto.Fecha,
-                        FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                        FechaLLegada = libroEntradaDto.FechaLLegada,
-                        Procedencia = libroEntradaDto.Procedencia,
-                        SitioExtraccion = muestraDto.SitioExtraccion,
-                        ColiformesNmp = string.Empty,
-                        ColiformesFecalesNmp = string.Empty,
-                        ColoniasAgar = string.Empty,
-                        ColiFecalesUfc = string.Empty,
-                        Observaciones = string.Empty,
-                        Muestra = muestra
-                    };
-                }
-                else if (tipoMuestra == TipoMuestra.FisicoQuimica)
-                {
-                    muestra.FisicoQuimico = new FisicoQuimico
-                    {
-                        Fecha = libroEntradaDto.Fecha,
-                        FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                        FechaLLegada = libroEntradaDto.FechaLLegada,
-                        Procedencia = libroEntradaDto.Procedencia,
-                        SitioExtraccion = muestraDto.SitioExtraccion,
-                        Ph = string.Empty,
-                        Turbidez = string.Empty,
-                        Alcalinidad = string.Empty,
-                        Dureza = string.Empty,
-                        Nitritos = string.Empty,
-                        Cloruros = string.Empty,
-                        Calcio = string.Empty,
-                        Magnesio = string.Empty,
-                        Dbo5 = string.Empty,
-                        Muestra = muestra
-                    };
-                }
-
-                muestras.Add(muestra);
+                muestras.Add(LibroDeEntradaFactory.CreateMuestra(muestraDto, libroEntradaDto, muestraDto.SitioExtraccion));
             }
 
-            var libroEntrada = new LibroDeEntrada
-            {
-                Fecha = libroEntradaDto.Fecha,
-                FechaLLegada = libroEntradaDto.FechaLLegada,
-                FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                Procedencia = libroEntradaDto.Procedencia,
-                SitioExtraccion = libroEntradaDto.SitioExtraccion ?? string.Empty,
-                Observaciones = libroEntradaDto.Observaciones,
-                Muestras = muestras
-            };
-
-            foreach (var muestra in muestras)
-            {
-                muestra.LibroEntrada = libroEntrada;
-            }
-
+            var libroEntrada = LibroDeEntradaFactory.CreateLibroEntrada(libroEntradaDto, muestras);
             await _libroEntradaRepository.AddAsync(libroEntrada);
         }
 
@@ -188,12 +114,7 @@ namespace Aplicacion.Services
                 if (cliente == null)
                     throw new NotFoundException($"Cliente con ID {muestraDto.ClienteId} no encontrado.");
 
-                TipoMuestra tipoMuestra = muestraDto.TipoMuestra switch
-                {
-                    TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
-                    TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
-                    _ => throw new ArgumentException("Tipo de muestra no válido.")
-                };
+                var tipoMuestra = LibroDeEntradaFactory.ParseTipoMuestra(muestraDto.TipoMuestra);
 
                 if (muestraExistente != null)
                 {
@@ -207,107 +128,16 @@ namespace Aplicacion.Services
                     muestraExistente.TipoMuestra = tipoMuestra;
                     muestraExistente.ClienteId = muestraDto.ClienteId;
 
-                    // Actualizar o crear entidad de análisis
-                    if (tipoMuestra == TipoMuestra.Bacteriologica)
-                    {
-                        if (muestraExistente.Bacteriologia == null)
-                        {
-                            muestraExistente.Bacteriologia = new Bacteriologico
-                            {
-                                Fecha = libroEntradaDto.Fecha,
-                                FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                                FechaLLegada = libroEntradaDto.FechaLLegada,
-                                Procedencia = libroEntradaDto.Procedencia,
-                                SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
-                                ColiformesNmp = string.Empty,
-                                ColiformesFecalesNmp = string.Empty,
-                                ColoniasAgar = string.Empty,
-                                ColiFecalesUfc = string.Empty,
-                                Observaciones = string.Empty,
-                                Muestra = muestraExistente
-                            };
-                        }
-                    }
-                    else if (tipoMuestra == TipoMuestra.FisicoQuimica)
-                    {
-                        if (muestraExistente.FisicoQuimico == null)
-                        {
-                            muestraExistente.FisicoQuimico = new FisicoQuimico
-                            {
-                                Fecha = libroEntradaDto.Fecha,
-                                FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                                FechaLLegada = libroEntradaDto.FechaLLegada,
-                                Procedencia = libroEntradaDto.Procedencia,
-                                SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
-                                Ph = string.Empty,
-                                Turbidez = string.Empty,
-                                Alcalinidad = string.Empty,
-                                Dureza = string.Empty,
-                                Nitritos = string.Empty,
-                                Cloruros = string.Empty,
-                                Calcio = string.Empty,
-                                Magnesio = string.Empty,
-                                Dbo5 = string.Empty,
-                                Muestra = muestraExistente
-                            };
-                        }
-                    }
+                    // Crear entidad de análisis si no existe todavía
+                    if (tipoMuestra == TipoMuestra.Bacteriologica && muestraExistente.Bacteriologia == null)
+                        muestraExistente.Bacteriologia = LibroDeEntradaFactory.CreateBacteriologico(libroEntradaDto, muestraDto, muestraExistente);
+                    else if (tipoMuestra == TipoMuestra.FisicoQuimica && muestraExistente.FisicoQuimico == null)
+                        muestraExistente.FisicoQuimico = LibroDeEntradaFactory.CreateFisicoQuimico(libroEntradaDto, muestraDto, muestraExistente);
                 }
                 else
                 {
                     // Agregar nueva muestra
-                    var nuevaMuestra = new Muestra
-                    {
-                        Procedencia = libroEntradaDto.Procedencia,
-                        NombreMuestreador = muestraDto.NombreMuestreador,
-                        Latitud = muestraDto.Latitud,
-                        Longitud = muestraDto.Longitud,
-                        FechaExtraccion = muestraDto.FechaExtraccion,
-                        HoraExtraccion = muestraDto.HoraExtraccion,
-                        TipoMuestra = tipoMuestra,
-                        ClienteId = muestraDto.ClienteId
-                    };
-
-                    if (tipoMuestra == TipoMuestra.Bacteriologica)
-                    {
-                        nuevaMuestra.Bacteriologia = new Bacteriologico
-                        {
-                            Fecha = libroEntradaDto.Fecha,
-                            FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                            FechaLLegada = libroEntradaDto.FechaLLegada,
-                            Procedencia = libroEntradaDto.Procedencia,
-                            SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
-                            ColiformesNmp = string.Empty,
-                            ColiformesFecalesNmp = string.Empty,
-                            ColoniasAgar = string.Empty,
-                            ColiFecalesUfc = string.Empty,
-                            Observaciones = string.Empty,
-                            Muestra = nuevaMuestra
-                        };
-                    }
-                    else if (tipoMuestra == TipoMuestra.FisicoQuimica)
-                    {
-                        nuevaMuestra.FisicoQuimico = new FisicoQuimico
-                        {
-                            Fecha = libroEntradaDto.Fecha,
-                            FechaAnalisis = libroEntradaDto.FechaAnalisis,
-                            FechaLLegada = libroEntradaDto.FechaLLegada,
-                            Procedencia = libroEntradaDto.Procedencia,
-                            SitioExtraccion = muestraDto.SitioExtraccion ?? string.Empty,
-                            Ph = string.Empty,
-                            Turbidez = string.Empty,
-                            Alcalinidad = string.Empty,
-                            Dureza = string.Empty,
-                            Nitritos = string.Empty,
-                            Cloruros = string.Empty,
-                            Calcio = string.Empty,
-                            Magnesio = string.Empty,
-                            Dbo5 = string.Empty,
-                            Muestra = nuevaMuestra
-                        };
-                    }
-
-                    muestrasActuales.Add(nuevaMuestra);
+                    muestrasActuales.Add(LibroDeEntradaFactory.CreateMuestra(muestraDto, libroEntradaDto, libroEntradaDto.Procedencia));
                 }
             }
 


### PR DESCRIPTION
Closes #54

## Cambios
- Nuevo `Aplicacion/Factories/LibroDeEntradaFactory.cs` con métodos estáticos:
  - `ParseTipoMuestra` — centraliza la conversión de enum DTO→dominio (elimina switch duplicado)
  - `CreateMuestra` — construye `Muestra` con análisis adjunto y `PuntoMuestreo` mapeado
  - `CreateBacteriologico` / `CreateFisicoQuimico` — construyen entidades de análisis vacías
  - `CreateLibroEntrada` — construye `LibroDeEntrada` con back-references a muestras
- `LibroDeEntradaService`: `RegistrarLibroEntradaAsync` y `UpdateLibroEntradaAsync` delegan toda construcción de entidades a la factory (−181 líneas de código inline)