### PR TITLE
refactor: reemplazar InMemoryDatabase por SQLite en Development

### DIFF
--- a/ApiLaboratorioAgua/ApiLaboratorioAgua.csproj
+++ b/ApiLaboratorioAgua/ApiLaboratorioAgua.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.16" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/ApiLaboratorioAgua/Program.cs
+++ b/ApiLaboratorioAgua/Program.cs
@@ -37,35 +37,27 @@ builder.Services.AddControllers()
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-// Configurar DbContext según el environment
+// Configurar DbContext — SQLite en todos los environments
 builder.Services.AddDbContext<LabAguaDbContext>(options =>
 {
-    if (builder.Environment.IsDevelopment())
+    var configured = builder.Configuration.GetConnectionString("defaultConnection");
+    var fallbackDb = builder.Environment.IsDevelopment() ? "LabAgua_Dev.db" : "LabAgua.db";
+    var dbPath = Path.Combine(AppContext.BaseDirectory, fallbackDb);
+
+    var conn = string.IsNullOrWhiteSpace(configured)
+        ? $"Data Source={dbPath}"
+        : configured;
+
+    // Si la connection string es relativa, anclala a la carpeta del exe
+    if (conn.StartsWith("Data Source=", StringComparison.OrdinalIgnoreCase))
     {
-        // Development: InMemory para rapidez en debug
-        options.UseInMemoryDatabase("LabAguaDb");
+        var value = conn.Substring("Data Source=".Length).Trim();
+        var isRelative = !Path.IsPathRooted(value);
+        if (isRelative)
+            conn = $"Data Source={Path.Combine(AppContext.BaseDirectory, value)}";
     }
-    else
-    {
-        // Production: SQLite para persistencia
-        var configured = builder.Configuration.GetConnectionString("defaultConnection");
-        var dbPath = Path.Combine(AppContext.BaseDirectory, "LabAgua.db");
-        
-        var conn = string.IsNullOrWhiteSpace(configured)
-            ? $"Data Source={dbPath}"
-            : configured;
-        
-        // Si la connection string es relativa, anclala a la carpeta del exe
-        if (conn.StartsWith("Data Source=", StringComparison.OrdinalIgnoreCase))
-        {
-            var value = conn.Substring("Data Source=".Length).Trim();
-            var isRelative = !Path.IsPathRooted(value);
-            if (isRelative)
-                conn = $"Data Source={Path.Combine(AppContext.BaseDirectory, value)}";
-        }
-        
-        options.UseSqlite(conn);
-    }
+
+    options.UseSqlite(conn);
 });
 
 
@@ -84,24 +76,21 @@ builder.Services.AddScoped<ReporteService>();
 builder.Services.AddScoped<PlanillaDiariaService>();
 var app = builder.Build();
 
-// Aplicar migraciones automáticas en Production (SQLite)
-if (!app.Environment.IsDevelopment())
+// Aplicar migraciones automáticas (SQLite en todos los environments)
 {
-    using (var scope = app.Services.CreateScope())
-    {
-        var db = scope.ServiceProvider.GetRequiredService<LabAguaDbContext>();
-        if (db.Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            db.Database.Migrate();
-        }
-    }
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<LabAguaDbContext>();
+    db.Database.Migrate();
 }
 
-// Seed datos solo en Development
+// Seed datos solo en Development (condicional: solo si la base está vacía)
 if (app.Environment.IsDevelopment())
 {
     using (var scope = app.Services.CreateScope())
     {
+        var db = scope.ServiceProvider.GetRequiredService<LabAguaDbContext>();
+        if (!db.Clientes.Any())
+        {
         var clienteService = scope.ServiceProvider.GetRequiredService<ClienteService>();
         var libroDeEntradaService = scope.ServiceProvider.GetRequiredService<LibroDeEntradaService>();
 
@@ -147,6 +136,7 @@ if (app.Environment.IsDevelopment())
             }
         };
         await libroDeEntradaService.RegistrarLibroEntradaAsync(libroEntradaDto);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #60\n\n## Cambios\n- **Program.cs**: SQLite en todos los environments (Development usa `LabAgua_Dev.db`, Production usa `LabAgua.db`)\n- **Program.cs**: Migraciones automáticas sin condicional de environment\n- **Program.cs**: Seed condicional `if (!db.Clientes.Any())` — solo corre si la base está vacía\n- **ApiLaboratorioAgua.csproj**: Removido `Microsoft.EntityFrameworkCore.InMemory`