### PR TITLE
fix: agregar includes en queries paginadas de PlanillaDiaria (#72)

### DIFF
--- a/Infrastructure/Repositories/PlanillaDiariaRepository.cs
+++ b/Infrastructure/Repositories/PlanillaDiariaRepository.cs
@@ -46,6 +46,9 @@ namespace Infrastructure.Repositories
         {
             var query = _context.PlanillasDiarias
                 .Include(p => p.EnsayoJarras)
+                .Include(p => p.LibroEntrada)
+                    .ThenInclude(le => le!.Muestras)
+                        .ThenInclude(m => m.FisicoQuimico)
                 .OrderByDescending(p => p.Fecha);
 
             var total = await query.CountAsync();
@@ -64,6 +67,9 @@ namespace Infrastructure.Repositories
 
             var query = _context.PlanillasDiarias
                 .Include(p => p.EnsayoJarras)
+                .Include(p => p.LibroEntrada)
+                    .ThenInclude(le => le!.Muestras)
+                        .ThenInclude(m => m.FisicoQuimico)
                 .Where(p => p.Fecha.Date >= desdeDate && p.Fecha.Date <= hastaDate)
                 .OrderByDescending(p => p.Fecha);
 


### PR DESCRIPTION
Closes #72

Agrega `.Include(p => p.LibroEntrada).ThenInclude(le => le!.Muestras).ThenInclude(m => m.FisicoQuimico)` en `GetAllPagedAsync` y `GetByFechaRangoPagedAsync` para que el listado de planillas incluya los datos de análisis físico-químico.