### PR TITLE
feat: agregar MuestraProcedencia a DTOs de FisicoQuimico y Bacteriologico

### DIFF
--- a/Aplicacion/Mappers/BacteriologicoMapper.cs
+++ b/Aplicacion/Mappers/BacteriologicoMapper.cs
@@ -19,7 +19,8 @@ namespace Aplicacion.Mappers
                 ColoniasAgar = b.ColoniasAgar,
                 ColiFecalesUfc = b.ColiFecalesUfc,
                 Observaciones = b.Observaciones,
-                MuestraId = b.MuestraId
+                MuestraId = b.MuestraId,
+                MuestraProcedencia = b.Muestra?.Procedencia
             };
         }
     }

--- a/Aplicacion/Mappers/FisicoQuimicoMapper.cs
+++ b/Aplicacion/Mappers/FisicoQuimicoMapper.cs
@@ -24,7 +24,8 @@ namespace Aplicacion.Mappers
                 Magnesio = fq.Magnesio,
                 Dbo5 = fq.Dbo5,
                 Cloro = fq.Cloro,
-                MuestraId = fq.MuestraId
+                MuestraId = fq.MuestraId,
+                MuestraProcedencia = fq.Muestra?.Procedencia
             };
         }
     }

--- a/Infrastructure/Dtos/BacteriologicoDto.cs
+++ b/Infrastructure/Dtos/BacteriologicoDto.cs
@@ -13,5 +13,6 @@ namespace Infrastructure.Dtos
         public string? ColiFecalesUfc { get; set; }
         public string? Observaciones { get; set; }
         public int MuestraId { get; set; }
+        public string? MuestraProcedencia { get; set; }
     }
 }

--- a/Infrastructure/Dtos/FisicoQuimicoDto.cs
+++ b/Infrastructure/Dtos/FisicoQuimicoDto.cs
@@ -18,5 +18,6 @@ namespace Infrastructure.Dtos
         public string? Dbo5 { get; set; }
         public string? Cloro { get; set; }
         public int MuestraId { get; set; }
+        public string? MuestraProcedencia { get; set; }
     }
 }


### PR DESCRIPTION
Closes #75\n\n- Agrega campo `MuestraProcedencia` a `FisicoQuimicoDto` y `BacteriologicoDto`\n- Actualiza mappers para navegar `entity.Muestra?.Procedencia`\n- Repositorios ya incluyen `.Include(x => x.Muestra)` en queries paginadas