### PR TITLE
fix: corregir firma nullable y agregar AsNoTracking en GetByIdAsync

### DIFF
--- a/Domain/IRepository/IRepository.cs
+++ b/Domain/IRepository/IRepository.cs
@@ -31,7 +31,7 @@ namespace Dominio.IRepository
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByProcedenciaPagedAsync(string procedencia, int page, int pageSize);
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize);
 
-        Task<LibroDeEntrada> GetByIdAsync(int id);
+        Task<LibroDeEntrada?> GetByIdAsync(int id);
         Task<List<LibroDeEntrada>> GetByProcedenciaAsync(string procedencia);
         Task<List<LibroDeEntrada>> GetByMuestraIdAsync(int muestraId);
         Task UpdateAsync(LibroDeEntrada libroEntrada);

--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -128,9 +128,10 @@ namespace Infrastructure.Repositories
             return (items, totalCount);
         }
 
-        public async Task<LibroDeEntrada> GetByIdAsync(int id)
+        public async Task<LibroDeEntrada?> GetByIdAsync(int id)
         {
             return await _context.LibroEntradas
+                .AsNoTracking()
                 .WithFullMuestras()
                 .FirstOrDefaultAsync(le => le.Id == id);
         }


### PR DESCRIPTION
Closes #27\n\n- Cambia firma de `ILibroEntradaRepository.GetByIdAsync` a `Task<LibroDeEntrada?>`\n- Agrega `.AsNoTracking()` a la query de `GetByIdAsync` en el repositorio\n- El service ya maneja `null` correctamente en los 3 callers\n\nConsultado Context7 para verificar patrón AsNoTracking + Update (disconnected entity).