### PR TITLE
refactor: segregar ILibroEntradaRepository en interfaces más pequeñas (ISP)

### DIFF
--- a/ApiLaboratorioAgua/Program.cs
+++ b/ApiLaboratorioAgua/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddDbContext<LabAguaDbContext>(options =>
 builder.Services.AddScoped<IClienteRepository, ClienteRepository>();
 builder.Services.AddScoped<IMuestraRepository, MuestraRepository>();
 builder.Services.AddScoped<ILibroEntradaRepository, LibroDeEntradaRepository>();
+builder.Services.AddScoped<ILibroEntradaQueryRepository, LibroDeEntradaRepository>();
 builder.Services.AddScoped<ILibroBacteriologiaRepository, BacteriologicoRepository>();
 builder.Services.AddScoped<ILibroFisicoQuimicoRepository, FisicoQuimicoRepository>();
 builder.Services.AddScoped<IPlanillaDiariaRepository, PlanillaDiariaRepository>();

--- a/Aplicacion/Services/LibroDeEntradaService.cs
+++ b/Aplicacion/Services/LibroDeEntradaService.cs
@@ -1,4 +1,4 @@
-﻿using Aplicacion.Factories;
+using Aplicacion.Factories;
 using Aplicacion.Mappers;
 using Infrastructure.Dtos;
 using Dominio.Exceptions;
@@ -10,22 +10,25 @@ namespace Aplicacion.Services
     public class LibroDeEntradaService
     {
         private readonly ILibroEntradaRepository _libroEntradaRepository;
+        private readonly ILibroEntradaQueryRepository _libroEntradaQueryRepository;
         private readonly IMuestraRepository _muestraRepository;
         private readonly IClienteRepository _clienteRepository;
 
         public LibroDeEntradaService(
             ILibroEntradaRepository libroEntradaRepository,
+            ILibroEntradaQueryRepository libroEntradaQueryRepository,
             IMuestraRepository muestraRepository,
             IClienteRepository clienteRepository)
         {
             _libroEntradaRepository = libroEntradaRepository;
+            _libroEntradaQueryRepository = libroEntradaQueryRepository;
             _muestraRepository = muestraRepository;
             _clienteRepository = clienteRepository;
         }
 
         public async Task<PagedResultDto<LibroDeEntradaResponseDto>> GetAllLibroEntradasAsync(int page = 1, int pageSize = 50)
         {
-            var (libros, totalCount) = await _libroEntradaRepository.GetAllPagedAsync(page, pageSize);
+            var (libros, totalCount) = await _libroEntradaQueryRepository.GetAllPagedAsync(page, pageSize);
             
             var items = libros.Select(le => le.ToDto()).ToList();
 
@@ -73,13 +76,13 @@ namespace Aplicacion.Services
                 throw new NotFoundException($"Muestra con ID {muestraId} no encontrada.");
             }
 
-            var libroEntradas = await _libroEntradaRepository.GetByMuestraIdAsync(muestraId);
+            var libroEntradas = await _libroEntradaQueryRepository.GetByMuestraIdAsync(muestraId);
             return libroEntradas.Select(le => le.ToDto()).ToList();
         }
 
         public async Task<List<LibroDeEntradaResponseDto>> GetLibroEntradasByProcedenciaAsync(string procedencia)
         {
-            var libros = await _libroEntradaRepository.GetByProcedenciaAsync(procedencia);
+            var libros = await _libroEntradaQueryRepository.GetByProcedenciaAsync(procedencia);
             return libros.Select(le => le.ToDto()).ToList();
         }
 
@@ -169,7 +172,7 @@ namespace Aplicacion.Services
         public async Task<PagedResultDto<LibroDeEntradaResponseDto>> GetLibroEntradasByProcedenciaPagedAsync(
             string procedencia, int page = 1, int pageSize = 50)
         {
-            var (libros, totalCount) = await _libroEntradaRepository.GetByProcedenciaPagedAsync(procedencia, page, pageSize);
+            var (libros, totalCount) = await _libroEntradaQueryRepository.GetByProcedenciaPagedAsync(procedencia, page, pageSize);
 
             var items = libros.Select(le => le.ToDto()).ToList();
 
@@ -185,7 +188,7 @@ namespace Aplicacion.Services
         public async Task<PagedResultDto<LibroDeEntradaResponseDto>> GetLibroEntradasByFechaRangoAsync(
             DateTime desde, DateTime hasta, int page = 1, int pageSize = 50)
         {
-            var (libros, totalCount) = await _libroEntradaRepository.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
+            var (libros, totalCount) = await _libroEntradaQueryRepository.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
 
             var items = libros.Select(le => le.ToDto()).ToList();
 

--- a/Aplicacion/Services/ReporteService.cs
+++ b/Aplicacion/Services/ReporteService.cs
@@ -11,9 +11,9 @@ namespace Aplicacion.Services
 {
     public class ReporteService
     {
-        private readonly ILibroEntradaRepository _libroEntradaRepository;
+        private readonly ILibroEntradaQueryRepository _libroEntradaRepository;
 
-        public ReporteService(ILibroEntradaRepository libroEntradaRepository)
+        public ReporteService(ILibroEntradaQueryRepository libroEntradaRepository)
         {
             _libroEntradaRepository = libroEntradaRepository;
         }

--- a/Domain/IRepository/IRepository.cs
+++ b/Domain/IRepository/IRepository.cs
@@ -1,4 +1,4 @@
-﻿using Dominio.Entities;
+using Dominio.Entities;
 
 namespace Dominio.IRepository
 {
@@ -24,17 +24,19 @@ namespace Dominio.IRepository
     {
         Task<LibroDeEntrada> AddAsync(LibroDeEntrada libroEntrada);
         Task DeleteAsync(int id);
+        Task<LibroDeEntrada?> GetByIdAsync(int id);
+        Task UpdateAsync(LibroDeEntrada libroEntrada);
+    }
+
+    public interface ILibroEntradaQueryRepository
+    {
+        Task<LibroDeEntrada?> GetByIdAsync(int id);
         Task<List<LibroDeEntrada>> GetAllAsync();
-        
-        // ✨ NUEVOS - Paginados
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize);
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByProcedenciaPagedAsync(string procedencia, int page, int pageSize);
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize);
-
-        Task<LibroDeEntrada?> GetByIdAsync(int id);
         Task<List<LibroDeEntrada>> GetByProcedenciaAsync(string procedencia);
         Task<List<LibroDeEntrada>> GetByMuestraIdAsync(int muestraId);
-        Task UpdateAsync(LibroDeEntrada libroEntrada);
     }
 
     public interface ILibroBacteriologiaRepository

--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Repositories
 {
-    public class LibroDeEntradaRepository: ILibroEntradaRepository
+    public class LibroDeEntradaRepository: ILibroEntradaRepository, ILibroEntradaQueryRepository
     {
         private readonly LabAguaDbContext _context;
 


### PR DESCRIPTION
## Summary
- Segregado `ILibroEntradaRepository` en dos interfaces siguiendo ISP (Interface Segregation Principle):
  - `ILibroEntradaRepository`: CRUD básico (Add, Update, Delete, GetById)
  - `ILibroEntradaQueryRepository`: queries especializadas (paginación, filtros por fecha/procedencia)
- `ReporteService` ahora depende solo de `ILibroEntradaQueryRepository` (solo usa GetByIdAsync)
- `LibroDeEntradaService` inyecta ambas interfaces según necesidad
- Misma implementación `LibroDeEntradaRepository` implementa ambas interfaces

## Files changed
- `Domain/IRepository/IRepository.cs` — nueva interfaz
- `Infrastructure/Repositories/LibroDeEntradaRepository.cs` — implementa ambas interfaces
- `Aplicacion/Services/LibroDeEntradaService.cs` — inyecta ambas
- `Aplicacion/Services/ReporteService.cs` — solo query interface
- `ApiLaboratorioAgua/Program.cs` — registro de DI