### PR TITLE
refactor: centralizar mapeo de enum TipoMuestra duplicado (OCP)

### DIFF
--- a/Aplicacion/Factories/LibroDeEntradaFactory.cs
+++ b/Aplicacion/Factories/LibroDeEntradaFactory.cs
@@ -1,21 +1,17 @@
 using Dominio.Entities;
 using Infrastructure.Dtos;
+using Aplicacion.Mappers;
 
 namespace Aplicacion.Factories
 {
     public static class LibroDeEntradaFactory
     {
         public static TipoMuestra ParseTipoMuestra(TipoDeMuestraDto tipoDto)
-            => tipoDto switch
-            {
-                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
-                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
-                _ => throw new ArgumentException($"Tipo de muestra no válido: {tipoDto}.")
-            };
+            => tipoDto.ToDomain();
 
         public static Muestra CreateMuestra(MuestraDto muestraDto, LibroDeEntradaDto libroDto, string? procedencia)
         {
-            var tipoMuestra = ParseTipoMuestra(muestraDto.TipoMuestra);
+            var tipoMuestra = muestraDto.TipoMuestra.ToDomain();
             var muestra = new Muestra
             {
                 Procedencia = procedencia,

--- a/Aplicacion/Mappers/MuestraMapper.cs
+++ b/Aplicacion/Mappers/MuestraMapper.cs
@@ -16,12 +16,7 @@ namespace Aplicacion.Mappers
                 Longitud = m.Longitud,
                 FechaExtraccion = m.FechaExtraccion,
                 HoraExtraccion = m.HoraExtraccion,
-                TipoMuestra = m.TipoMuestra switch
-                {
-                    TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                    TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                    _ => throw new ArgumentException("Tipo de muestra no válido.")
-                },
+                TipoMuestra = m.TipoMuestra.ToDto(),
                 ClienteId = m.ClienteId,
                 ClienteNombre = m.Cliente?.Nombre,
                 LibroEntradaId = m.LibroEntradaId

--- a/Aplicacion/Mappers/ReporteMapper.cs
+++ b/Aplicacion/Mappers/ReporteMapper.cs
@@ -14,12 +14,7 @@ namespace Aplicacion.Mappers
                 SitioExtraccion = m.Procedencia,
                 NombreMuestreador = m.NombreMuestreador,
                 HoraExtraccion = m.HoraExtraccion,
-                TipoMuestra = m.TipoMuestra switch
-                {
-                    TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
-                    TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
-                    _ => throw new ArgumentException("Tipo de muestra no válido.")
-                },
+                TipoMuestra = m.TipoMuestra.ToDto(),
                 ClienteId = m.ClienteId,
                 ClienteNombre = m.Cliente?.Nombre,
                 Bacteriologia = m.Bacteriologia?.ToDto(),

--- a/Aplicacion/Mappers/TipoMuestraMapper.cs
+++ b/Aplicacion/Mappers/TipoMuestraMapper.cs
@@ -1,0 +1,28 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class TipoMuestraMapper
+    {
+        public static TipoMuestra ToDomain(this TipoDeMuestraDto dto)
+        {
+            return dto switch
+            {
+                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
+                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
+                _ => throw new ArgumentException("Tipo de muestra no válido.")
+            };
+        }
+
+        public static TipoDeMuestraDto ToDto(this TipoMuestra domain)
+        {
+            return domain switch
+            {
+                TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
+                TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
+                _ => throw new ArgumentException("Tipo de muestra no válido.")
+            };
+        }
+    }
+}

--- a/Aplicacion/Services/MuestraService.cs
+++ b/Aplicacion/Services/MuestraService.cs
@@ -1,4 +1,4 @@
-﻿using Aplicacion.Mappers;
+using Aplicacion.Mappers;
 using Infrastructure.Dtos;
 using Dominio.Exceptions;
 using Dominio.Entities;
@@ -35,12 +35,7 @@ namespace Aplicacion.Services
                 throw new NotFoundException($"Cliente con ID {muestraDto.ClienteId} no encontrado.");
 
             // Mapear TipoMuestraDto a TipoMuestra
-            TipoMuestra tipoMuestra = muestraDto.TipoMuestra switch
-            {
-                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
-                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
-                _ => throw new ArgumentException("Tipo de muestra no válido.")
-            };
+            var tipoMuestra = muestraDto.TipoMuestra.ToDomain();
 
             var muestra = new Muestra
             {


### PR DESCRIPTION
## Summary
- Crear `TipoMuestraMapper` centralizado en `Aplicacion/Mappers/` con métodos de extensión `ToDomain()` y `ToDto()`
- Eliminar switch duplicado en 4 archivos:
  - `MuestraService.cs`
  - `ReporteMapper.cs`
  - `MuestraMapper.cs`
  - `LibroDeEntradaFactory.cs`

## Cambios
- Nuevo archivo: `Aplicacion/Mappers/TipoMuestraMapper.cs`
- Mappers ahora usan `.ToDto()` en lugar de switch inline
- Services ahora usan `.ToDomain()` en lugar de switch inline
- Al agregar un nuevo tipo de muestra, solo se modifica `TipoMuestraMapper.cs`

## Cierre
Cierra #47