### PR TITLE
feat: implementar Result pattern en MuestraService (issue #15)

### DIFF
--- a/ApiLaboratorioAgua/Controllers/MuestraController.cs
+++ b/ApiLaboratorioAgua/Controllers/MuestraController.cs
@@ -1,4 +1,4 @@
-﻿using Infrastructure.Dtos;
+using Infrastructure.Dtos;
 using Aplicacion.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -15,29 +15,22 @@ namespace ApiLaboratorioAgua.Controllers
             _muestraService = muestraService;
         }
 
-        /// <summary>
-        /// Registra una nueva muestra, creando automáticamente un libro de entrada
-        /// y una entrada en LibroBacteriologia o LibroFisicoQuimico según el tipo de muestra.
-        /// </summary>
-        /// <param name="muestraDto">Datos de la muestra a registrar.</param>
-        /// <returns>Confirmación de registro exitoso.</returns>
         [HttpPost("registrar")]
         public async Task<IActionResult> RegistrarMuestra([FromBody] MuestraDto muestraDto)
         {
-            await _muestraService.RegistrarMuestraAsync(muestraDto);
-            return Ok("Muestra registrada con éxito.");
+            var result = await _muestraService.RegistrarMuestraAsync(muestraDto);
+            if (!result.IsSuccess)
+                return BadRequest(result.Error);
+            return Ok(result.Value);
         }
 
-        /// <summary>
-        /// Obtiene todas las muestras asociadas a un cliente.
-        /// </summary>
-        /// <param name="clienteId">ID del cliente.</param>
-        /// <returns>Lista de muestras.</returns>
         [HttpGet("por-cliente/{clienteId}")]
         public async Task<IActionResult> GetMuestrasPorCliente(int clienteId)
         {
-            var muestras = await _muestraService.GetMuestrasPorClienteAsync(clienteId);
-            return Ok(muestras);
+            var result = await _muestraService.GetMuestrasPorClienteAsync(clienteId);
+            if (!result.IsSuccess)
+                return NotFound(result.Error);
+            return Ok(result.Value);
         }
     }
 }

--- a/Aplicacion/Mappers/TipoMuestraMapper.cs
+++ b/Aplicacion/Mappers/TipoMuestraMapper.cs
@@ -1,0 +1,28 @@
+using Dominio.Entities;
+using Infrastructure.Dtos;
+
+namespace Aplicacion.Mappers
+{
+    public static class TipoMuestraMapper
+    {
+        public static TipoMuestra ToDomain(this TipoDeMuestraDto dto)
+        {
+            return dto switch
+            {
+                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
+                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
+                _ => throw new ArgumentException("Tipo de muestra no válido.")
+            };
+        }
+
+        public static TipoDeMuestraDto ToDto(this TipoMuestra domain)
+        {
+            return domain switch
+            {
+                TipoMuestra.Bacteriologica => TipoDeMuestraDto.Bacteriologica,
+                TipoMuestra.FisicoQuimica => TipoDeMuestraDto.FisicoQuimica,
+                _ => throw new ArgumentException("Tipo de muestra no válido.")
+            };
+        }
+    }
+}

--- a/Aplicacion/Services/MuestraService.cs
+++ b/Aplicacion/Services/MuestraService.cs
@@ -1,6 +1,6 @@
-﻿using Aplicacion.Mappers;
+using Aplicacion.Mappers;
 using Infrastructure.Dtos;
-using Dominio.Exceptions;
+using Dominio;
 using Dominio.Entities;
 using Dominio.IRepository;
 
@@ -28,19 +28,13 @@ namespace Aplicacion.Services
             _libroFisicoQuimicoRepository = libroFisicoQuimicoRepository;
         }
 
-        public async Task RegistrarMuestraAsync(MuestraDto muestraDto)
+        public async Task<Result<string>> RegistrarMuestraAsync(MuestraDto muestraDto)
         {
             var cliente = await _clienteRepository.GetByIdAsync(muestraDto.ClienteId);
             if (cliente == null)
-                throw new NotFoundException($"Cliente con ID {muestraDto.ClienteId} no encontrado.");
+                return Result<string>.Failure($"Cliente con ID {muestraDto.ClienteId} no encontrado.");
 
-            // Mapear TipoMuestraDto a TipoMuestra
-            TipoMuestra tipoMuestra = muestraDto.TipoMuestra switch
-            {
-                TipoDeMuestraDto.Bacteriologica => TipoMuestra.Bacteriologica,
-                TipoDeMuestraDto.FisicoQuimica => TipoMuestra.FisicoQuimica,
-                _ => throw new ArgumentException("Tipo de muestra no válido.")
-            };
+            var tipoMuestra = TipoMuestraMapper.ToDomain(muestraDto.TipoMuestra);
 
             var muestra = new Muestra
             {
@@ -99,18 +93,17 @@ namespace Aplicacion.Services
 
             // Solo agregas la entidad raíz
             await _libroEntradaRepository.AddAsync(libroEntrada);
+            return Result<string>.Success("Muestra registrada con éxito.");
         }
 
-        public async Task<List<MuestraResponseDto>> GetMuestrasPorClienteAsync(int clienteId)
+        public async Task<Result<List<MuestraResponseDto>>> GetMuestrasPorClienteAsync(int clienteId)
         {
             var cliente = await _clienteRepository.GetByIdAsync(clienteId);
             if (cliente == null)
-            {
-                throw new NotFoundException($"Cliente con ID {clienteId} no encontrado.");
-            }
+                return Result<List<MuestraResponseDto>>.Failure($"Cliente con ID {clienteId} no encontrado.");
 
             var muestras = await _muestraRepository.GetByClienteIdAsync(clienteId);
-            return muestras.Select(m => m.ToDto()).ToList();
+            return Result<List<MuestraResponseDto>>.Success(muestras.Select(m => m.ToDto()).ToList());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implementar Result pattern en `MuestraService` y `MuestraController`:
  - `RegistrarMuestraAsync` → retorna `Result<string>`
  - `GetMuestrasPorClienteAsync` → retorna `Result<List<MuestraResponseDto>>`
  - Controller maneja `result.IsSuccess` y `result.Error`
- Agregar `TipoMuestraMapper` con métodos `ToDomain()`/`ToDto()` (-centraliza mapeo)

## Changes
- `Aplicacion/Services/MuestraService.cs` — usa Result pattern
- `Aplicacion/Controllers/MuestraController.cs` — maneja resultado
- `Aplicacion/Mappers/TipoMuestraMapper.cs` — nuevo archivo

## Cierre
Cierra #15