### PR TITLE
refactor: centralizar guards de paginacion con PaginationDefaults (OCP) #46

### DIFF
--- a/Domain/Constants/PaginationDefaults.cs
+++ b/Domain/Constants/PaginationDefaults.cs
@@ -1,0 +1,16 @@
+namespace Dominio.Constants;
+
+public static class PaginationDefaults
+{
+    public const int DefaultPageSize = 50;
+    public const int MaxPageSize = 500;
+
+    public static (int Page, int PageSize) Normalize(int page, int pageSize)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = DefaultPageSize;
+        if (pageSize > MaxPageSize) pageSize = MaxPageSize;
+
+        return (page, pageSize);
+    }
+}

--- a/Infrastructure/Repositories/BacteriologicoRepository.cs
+++ b/Infrastructure/Repositories/BacteriologicoRepository.cs
@@ -1,3 +1,4 @@
+using Dominio.Constants;
 using Dominio.Entities;
 using Dominio.IRepository;
 using Infrastructure.Data;
@@ -29,9 +30,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<Bacteriologico> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.Bacteriologicos
                 .AsNoTracking()
@@ -49,9 +48,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<Bacteriologico> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var desdeDate = desde.Date;
             var hastaDate = hasta.Date.AddDays(1);
@@ -73,9 +70,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<Bacteriologico> Items, int TotalCount)> GetByClienteIdPagedAsync(int clienteId, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.Bacteriologicos
                 .AsNoTracking()

--- a/Infrastructure/Repositories/FisicoQuimicoRepository.cs
+++ b/Infrastructure/Repositories/FisicoQuimicoRepository.cs
@@ -1,3 +1,4 @@
+using Dominio.Constants;
 using Dominio.Entities;
 using Dominio.IRepository;
 using Infrastructure.Data;
@@ -30,9 +31,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<FisicoQuimico> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.FisicoQuimicos
                 .AsNoTracking()
@@ -50,9 +49,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<FisicoQuimico> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var desdeDate = desde.Date;
             var hastaDate = hasta.Date.AddDays(1);
@@ -74,9 +71,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<FisicoQuimico> Items, int TotalCount)> GetByClienteIdPagedAsync(int clienteId, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.FisicoQuimicos
                 .AsNoTracking()

--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -1,3 +1,4 @@
+using Dominio.Constants;
 using Dominio.Entities;
 using Dominio.IRepository;
 using Infrastructure.Data;
@@ -55,12 +56,9 @@ namespace Infrastructure.Repositories
         /// <summary>
         /// Obtiene libros de entrada con paginaci�n
         /// </summary>
-        public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
+public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
         {
-            // Validar par�metros
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500; // Limitar m�ximo
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.LibroEntradas
                 .AsNoTracking()
@@ -84,9 +82,7 @@ namespace Infrastructure.Repositories
         /// </summary>
         public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByProcedenciaPagedAsync(string procedencia, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var query = _context.LibroEntradas
                 .AsNoTracking()
@@ -106,9 +102,7 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-            if (pageSize > 500) pageSize = 500;
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var desdeDate = desde.Date;
             var hastaDate = hasta.Date;

--- a/Infrastructure/Repositories/PlanillaDiariaRepository.cs
+++ b/Infrastructure/Repositories/PlanillaDiariaRepository.cs
@@ -1,3 +1,4 @@
+using Dominio.Constants;
 using Dominio.Entities;
 using Dominio.IRepository;
 using Infrastructure.Data;
@@ -44,6 +45,8 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<PlanillaDiaria> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
         {
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
+
             var query = _context.PlanillasDiarias
                 .Include(p => p.EnsayoJarras)
                 .Include(p => p.LibroEntrada)
@@ -62,6 +65,8 @@ namespace Infrastructure.Repositories
 
         public async Task<(List<PlanillaDiaria> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize)
         {
+            (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
+
             var desdeDate = desde.Date;
             var hastaDate = hasta.Date;
 


### PR DESCRIPTION
## Summary
- Centraliza constantes de paginación (DefaultPageSize=50, MaxPageSize=500) en nueva clase `PaginationDefaults`
- Crea método `Normalize(page, pageSize)` que encapsula la lógica de validación
- Reemplaza 29 guards duplicados en 4 repositorios por llamada a `PaginationDefaults.Normalize()`
- Prepara terreno para Issue #43 (ActionFilter de paginación)

## Files
- NEW: `Domain/Constants/PaginationDefaults.cs`
- MODIFIED: `BacteriologicoRepository.cs`, `FisicoQuimicoRepository.cs`, `LibroDeEntradaRepository.cs`, `PlanillaDiariaRepository.cs`

Closes #46