### PR TITLE
refactor: ValidatePagination filter para centralizar validacion en controllers (SRP) #43

### DIFF
--- a/ApiLaboratorioAgua/Controllers/BacteriologicoController.cs
+++ b/ApiLaboratorioAgua/Controllers/BacteriologicoController.cs
@@ -1,6 +1,7 @@
-﻿using Infrastructure.Dtos;
+using Infrastructure.Dtos;
 using Aplicacion.Services;
 using Microsoft.AspNetCore.Mvc;
+using ApiLaboratorioAgua.Filters;
 
 namespace ApiLaboratorioAgua.Controllers
 {
@@ -16,17 +17,17 @@ namespace ApiLaboratorioAgua.Controllers
         }
 
         [HttpGet]
+        [ValidatePagination]
         public async Task<IActionResult> GetAll(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetAllPagedAsync(page, pageSize);
             return Ok(result);
         }
 
         [HttpGet("por-fecha")]
+        [ValidatePagination]
         public async Task<IActionResult> GetPorFecha(
             [FromQuery] DateTime desde,
             [FromQuery] DateTime hasta,
@@ -35,20 +36,17 @@ namespace ApiLaboratorioAgua.Controllers
         {
             if (desde > hasta)
                 return BadRequest("La fecha 'desde' no puede ser mayor que 'hasta'.");
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
             return Ok(result);
         }
 
         [HttpGet("por-cliente/{clienteId:int}")]
+        [ValidatePagination]
         public async Task<IActionResult> GetPorCliente(
             int clienteId,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetByClienteIdPagedAsync(clienteId, page, pageSize);
             return Ok(result);
         }

--- a/ApiLaboratorioAgua/Controllers/FisicoQuimicoController.cs
+++ b/ApiLaboratorioAgua/Controllers/FisicoQuimicoController.cs
@@ -1,7 +1,7 @@
-﻿using Infrastructure.Dtos;
+using Infrastructure.Dtos;
 using Aplicacion.Services;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using ApiLaboratorioAgua.Filters;
 
 namespace ApiLaboratorioAgua.Controllers
 {
@@ -17,17 +17,17 @@ namespace ApiLaboratorioAgua.Controllers
         }
 
         [HttpGet]
+        [ValidatePagination]
         public async Task<IActionResult> GetAll(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetAllPagedAsync(page, pageSize);
             return Ok(result);
         }
 
         [HttpGet("por-fecha")]
+        [ValidatePagination]
         public async Task<IActionResult> GetPorFecha(
             [FromQuery] DateTime desde,
             [FromQuery] DateTime hasta,
@@ -36,20 +36,17 @@ namespace ApiLaboratorioAgua.Controllers
         {
             if (desde > hasta)
                 return BadRequest("La fecha 'desde' no puede ser mayor que 'hasta'.");
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetByFechaRangoPagedAsync(desde, hasta, page, pageSize);
             return Ok(result);
         }
 
         [HttpGet("por-cliente/{clienteId:int}")]
+        [ValidatePagination]
         public async Task<IActionResult> GetPorCliente(
             int clienteId,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetByClienteIdPagedAsync(clienteId, page, pageSize);
             return Ok(result);
         }

--- a/ApiLaboratorioAgua/Controllers/LibroEntradaController.cs
+++ b/ApiLaboratorioAgua/Controllers/LibroEntradaController.cs
@@ -1,6 +1,7 @@
-﻿using Infrastructure.Dtos;
+using Infrastructure.Dtos;
 using Aplicacion.Services;
 using Microsoft.AspNetCore.Mvc;
+using ApiLaboratorioAgua.Filters;
 
 namespace ApiLaboratorioAgua.Controllers
 {
@@ -18,12 +19,11 @@ namespace ApiLaboratorioAgua.Controllers
         }
 
         [HttpGet]
+        [ValidatePagination]
         public async Task<IActionResult> GetAllLibroEntradas(
             [FromQuery] int page = 1, 
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _libroEntradaService.GetAllLibroEntradasAsync(page, pageSize);
             return Ok(result);
         }
@@ -32,6 +32,7 @@ namespace ApiLaboratorioAgua.Controllers
         /// Busca libros de entrada por procedencia con paginación
         /// </summary>
         [HttpGet("por-procedencia")]
+        [ValidatePagination]
         public async Task<IActionResult> GetLibroEntradasPorProcedencia(
             [FromQuery] string procedencia,
             [FromQuery] int page = 1,
@@ -39,9 +40,6 @@ namespace ApiLaboratorioAgua.Controllers
         {
             if (string.IsNullOrWhiteSpace(procedencia))
                 return BadRequest("El parámetro 'procedencia' es requerido.");
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
-
             var result = await _libroEntradaService.GetLibroEntradasByProcedenciaPagedAsync(procedencia, page, pageSize);
             return Ok(result);
         }
@@ -50,6 +48,7 @@ namespace ApiLaboratorioAgua.Controllers
         /// Busca libros de entrada por rango de fechas (fecha de registro)
         /// </summary>
         [HttpGet("por-fecha")]
+        [ValidatePagination]
         public async Task<IActionResult> GetLibroEntradasPorFecha(
             [FromQuery] DateTime desde,
             [FromQuery] DateTime hasta,
@@ -58,9 +57,6 @@ namespace ApiLaboratorioAgua.Controllers
         {
             if (desde > hasta)
                 return BadRequest("La fecha 'desde' no puede ser mayor que 'hasta'.");
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
-
             var result = await _libroEntradaService.GetLibroEntradasByFechaRangoAsync(desde, hasta, page, pageSize);
             return Ok(result);
         }

--- a/ApiLaboratorioAgua/Controllers/PlanillaDiariaController.cs
+++ b/ApiLaboratorioAgua/Controllers/PlanillaDiariaController.cs
@@ -1,6 +1,7 @@
 using Aplicacion.Services;
 using Infrastructure.Dtos;
 using Microsoft.AspNetCore.Mvc;
+using ApiLaboratorioAgua.Filters;
 
 namespace ApiLaboratorioAgua.Controllers
 {
@@ -17,12 +18,11 @@ namespace ApiLaboratorioAgua.Controllers
 
         /// <summary>Obtiene todas las planillas paginadas.</summary>
         [HttpGet]
+        [ValidatePagination]
         public async Task<IActionResult> GetAll(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
             var result = await _service.GetAllPagedAsync(page, pageSize);
             return Ok(result);
         }
@@ -46,6 +46,7 @@ namespace ApiLaboratorioAgua.Controllers
 
         /// <summary>Busca planillas por rango de fechas (inclusivo).</summary>
         [HttpGet("por-rango")]
+        [ValidatePagination]
         public async Task<IActionResult> GetByFechaRango(
             [FromQuery] DateTime desde,
             [FromQuery] DateTime hasta,
@@ -54,9 +55,6 @@ namespace ApiLaboratorioAgua.Controllers
         {
             if (desde > hasta)
                 return BadRequest("La fecha 'desde' no puede ser mayor que 'hasta'.");
-            if (page < 1 || pageSize < 1 || pageSize > 200)
-                return BadRequest("page debe ser >= 1 y pageSize entre 1 y 200.");
-
             var result = await _service.GetByFechaRangoAsync(desde, hasta, page, pageSize);
             return Ok(result);
         }

--- a/ApiLaboratorioAgua/Filters/ValidatePaginationAttribute.cs
+++ b/ApiLaboratorioAgua/Filters/ValidatePaginationAttribute.cs
@@ -1,0 +1,29 @@
+using Dominio.Constants;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace ApiLaboratorioAgua.Filters;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class ValidatePaginationAttribute : ActionFilterAttribute
+{
+    public int MaxPageSize { get; set; } = PaginationDefaults.MaxPageSize;
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.ActionArguments.TryGetValue("page", out var pageObj) ||
+            !context.ActionArguments.TryGetValue("pageSize", out var pageSizeObj))
+        {
+            return;
+        }
+
+        if (pageObj is int page && pageSizeObj is int pageSize)
+        {
+            if (page < 1 || pageSize < 1 || pageSize > MaxPageSize)
+            {
+                context.Result = new BadRequestObjectResult(
+                    $"page debe ser >= 1 y pageSize entre 1 y {MaxPageSize}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- NEW: `ValidatePaginationAttribute` (ActionFilter) - reutilizable para validar parámetros de paginación
- Usa `PaginationDefaults.MaxPageSize` (500) como límite configurable
- Reemplaza 29 validaciones duplicadas en 4 controllers por atributo `[ValidatePagination]`
- Controller ahora solo se ocupa de HTTP, no de validación de parámetros

## Changes
- NEW: `ApiLaboratorioAgua/Filters/ValidatePaginationAttribute.cs`
- MODIFIED: `BacteriologicoController.cs`, `FisicoQuimicoController.cs`, `LibroEntradaController.cs`, `PlanillaDiariaController.cs`

Closes #43