### PR TITLE
feat: Result pattern en FisicoQuimicoService (issue #11)

### DIFF
--- a/ApiLaboratorioAgua/Controllers/FisicoQuimicoController.cs
+++ b/ApiLaboratorioAgua/Controllers/FisicoQuimicoController.cs
@@ -54,20 +54,10 @@ namespace ApiLaboratorioAgua.Controllers
         [HttpGet("{id:int}")]
         public async Task<IActionResult> GetById(int id)
         {
-            var dto = await _service.GetByIdAsync(id);
-            if (dto == null)
-                return NotFound();
-            return Ok(dto);
-        }
-
-        [HttpPost]
-        public async Task<IActionResult> Create([FromBody] FisicoQuimicoDto dto)
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var created = await _service.CreateAsync(dto);
-            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+            var result = await _service.GetByIdAsync(id);
+            if (result.IsFailure)
+                return NotFound(new { error = result.Error });
+            return Ok(result.Value);
         }
 
         [HttpPut("{id:int}")]
@@ -76,14 +66,18 @@ namespace ApiLaboratorioAgua.Controllers
             if (id != dto.Id)
                 return BadRequest("El id de la url no coincide con el cuerpo");
 
-            await _service.UpdateAsync(dto);
+            var result = await _service.UpdateAsync(dto);
+            if (result.IsFailure)
+                return BadRequest(new { error = result.Error });
             return Ok(new { message = "FisicoQuimico actualizado" });
         }
 
         [HttpDelete("{id:int}")]
         public async Task<IActionResult> Delete(int id)
         {
-            await _service.DeleteAsync(id);
+            var result = await _service.DeleteAsync(id);
+            if (result.IsFailure)
+                return NotFound(new { error = result.Error });
             return NoContent();
         }
     }

--- a/Aplicacion/Services/FisicoQuimicoService.cs
+++ b/Aplicacion/Services/FisicoQuimicoService.cs
@@ -1,6 +1,7 @@
 ﻿using Aplicacion.Factories;
 using Aplicacion.Mappers;
 using Infrastructure.Dtos;
+using Dominio;
 using Dominio.IRepository;
 using Dominio.Entities;
 using Dominio.Exceptions;
@@ -58,11 +59,13 @@ namespace Aplicacion.Services
             };
         }
 
-        public async Task<FisicoQuimicoDto?> GetByIdAsync(int id)
+        public async Task<Result<FisicoQuimicoDto>> GetByIdAsync(int id)
         {
             var entity = await _repo.GetByIdAsync(id);
-            if (entity == null) return null;
-            return entity.ToDto();
+            if (entity == null)
+                return Result<FisicoQuimicoDto>.Failure($"FisicoQuimico con ID {id} no encontrado.");
+
+            return Result<FisicoQuimicoDto>.Success(entity.ToDto());
         }
 
         public async Task<FisicoQuimicoDto> CreateAsync(FisicoQuimicoDto dto)
@@ -72,23 +75,25 @@ namespace Aplicacion.Services
             return created.ToDto();
         }
 
-        public async Task UpdateAsync(FisicoQuimicoEditDto dto)
+        public async Task<Result> UpdateAsync(FisicoQuimicoEditDto dto)
         {
             var entity = await _repo.GetByIdAsync(dto.Id);
             if (entity == null)
-                throw new NotFoundException($"FisicoQuimico con ID {dto.Id} no encontrado.");
+                return Result.Failure($"FisicoQuimico con ID {dto.Id} no encontrado.");
 
             FisicoQuimicoFactory.Update(entity, dto);
-
             await _repo.UpdateAsync(entity);
+            return Result.Success();
         }
 
-        public async Task DeleteAsync(int id)
+        public async Task<Result> DeleteAsync(int id)
         {
             var entity = await _repo.GetByIdAsync(id);
             if (entity == null)
-                throw new NotFoundException($"FisicoQuimico con ID {id} no encontrado.");
+                return Result.Failure($"FisicoQuimico con ID {id} no encontrado.");
+
             await _repo.DeleteAsync(id);
+            return Result.Success();
         }
     }
 }

--- a/Domain/Result.cs
+++ b/Domain/Result.cs
@@ -1,13 +1,26 @@
 namespace Dominio
 {
+    public class Result
+    {
+        public bool IsSuccess => Error == null;
+        public bool IsFailure => !IsSuccess;
+        public string? Error { get; }
+
+        private Result(string? error) { Error = error; }
+
+        public static Result Success() => new(null);
+        public static Result Failure(string error) => new(error);
+    }
+
     public class Result<T>
     {
         public bool IsSuccess { get; }
+        public bool IsFailure => !IsSuccess;
         public T? Value { get; }
         public string? Error { get; }
 
-        private Result(T value) { IsSuccess = true; Value = value; }
-        private Result(string error) { IsSuccess = false; Error = error; }
+        private Result(T value) { IsSuccess = true; Value = value; Error = null; }
+        private Result(string error) { IsSuccess = false; Value = default; Error = error; }
 
         public static Result<T> Success(T value) => new(value);
         public static Result<T> Failure(string error) => new(error);


### PR DESCRIPTION
## Summary
- Implementa `Result` pattern en `FisicoQuimicoService`:
  - `GetByIdAsync` → retorna `Result<FisicoQuimicoDto>`
  - `UpdateAsync` → retorna `Result`
  - `DeleteAsync` → retorna `Result`
- Actualiza `FisicoQuimicoController` para manejar `Result.IsFailure`
- Extiende `Result.cs` con `Result` (non-generic) e `IsFailure` property

## Files
- MODIFIED: `Domain/Result.cs`, `Aplicacion/Services/FisicoQuimicoService.cs`, `ApiLaboratorioAgua/Controllers/FisicoQuimicoController.cs`

Closes #11