### PR TITLE
feat: agregar Cloro en reporte PDF de Libro de Entrada

### DIFF
--- a/Aplicacion/Services/ReporteService.cs
+++ b/Aplicacion/Services/ReporteService.cs
@@ -89,6 +89,7 @@ namespace Aplicacion.Services
                                     c2.Item().Text($"Calcio: {m.FisicoQuimico.Calcio}");
                                     c2.Item().Text($"Magnesio: {m.FisicoQuimico.Magnesio}");
                                     c2.Item().Text($"DBO5: {m.FisicoQuimico.Dbo5}");
+                                    c2.Item().Text($"Cloro: {m.FisicoQuimico.Cloro}");
                                 }
                             });
                         }


### PR DESCRIPTION
## Summary
- Agrega la propiedad `Cloro` al reporte PDF de Libro de Entrada en la sección Fisicoquímico.
- La propiedad ya existía en la entidad `FisicoQuimico.Cloro` y el DTO, pero no se mostraba en el PDF.

## Files
- MODIFIED: `Aplicacion/Services/ReporteService.cs` (+1 línea)