### PR TITLE
feat: agregar Amonio y Nitratos a FisicoQuimico

### DIFF
--- a/Aplicacion/Factories/FisicoQuimicoFactory.cs
+++ b/Aplicacion/Factories/FisicoQuimicoFactory.cs
@@ -17,6 +17,8 @@ namespace Aplicacion.Factories
                 Alcalinidad = dto.Alcalinidad,
                 Dureza = dto.Dureza,
                 Nitritos = dto.Nitritos,
+                Nitratos = dto.Nitratos,
+                Amonio = dto.Amonio,
                 Cloruros = dto.Cloruros,
                 Calcio = dto.Calcio,
                 Magnesio = dto.Magnesio,
@@ -32,6 +34,8 @@ namespace Aplicacion.Factories
             entity.Alcalinidad = dto.Alcalinidad;
             entity.Dureza = dto.Dureza;
             entity.Nitritos = dto.Nitritos;
+            entity.Nitratos = dto.Nitratos;
+            entity.Amonio = dto.Amonio;
             entity.Cloruros = dto.Cloruros;
             entity.Calcio = dto.Calcio;
             entity.Magnesio = dto.Magnesio;

--- a/Aplicacion/Mappers/FisicoQuimicoMapper.cs
+++ b/Aplicacion/Mappers/FisicoQuimicoMapper.cs
@@ -19,6 +19,8 @@ namespace Aplicacion.Mappers
                 Alcalinidad = fq.Alcalinidad,
                 Dureza = fq.Dureza,
                 Nitritos = fq.Nitritos,
+                Nitratos = fq.Nitratos,
+                Amonio = fq.Amonio,
                 Cloruros = fq.Cloruros,
                 Calcio = fq.Calcio,
                 Magnesio = fq.Magnesio,

--- a/Aplicacion/Services/ReporteService.cs
+++ b/Aplicacion/Services/ReporteService.cs
@@ -87,7 +87,7 @@ namespace Aplicacion.Services
                                 var hasObs = bactSamples.Any(m => !string.IsNullOrEmpty(m.Bacteriologia?.Observaciones));
                                 if (hasObs)
                                 {
-                                    tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("Observaciones de Muestra").Bold().FontSize(8);
+                                    tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("Observaciones").Bold().FontSize(8);
                                     foreach (var m in bactSamples)
                                         tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).AlignCenter().Text(m.Bacteriologia?.Observaciones ?? "-").FontSize(8);
                                 }
@@ -138,6 +138,8 @@ namespace Aplicacion.Services
                                 AgregarFilaFq(tabla, "Alcalinidad", fqSamples.Select(m => m.FisicoQuimico?.Alcalinidad ?? "-").ToList());
                                 AgregarFilaFq(tabla, "Dureza", fqSamples.Select(m => m.FisicoQuimico?.Dureza ?? "-").ToList());
                                 AgregarFilaFq(tabla, "Nitritos", fqSamples.Select(m => m.FisicoQuimico?.Nitritos ?? "-").ToList());
+                                AgregarFilaFq(tabla, "Nitratos", fqSamples.Select(m => m.FisicoQuimico?.Nitratos ?? "-").ToList());
+                                AgregarFilaFq(tabla, "Amonio", fqSamples.Select(m => m.FisicoQuimico?.Amonio ?? "-").ToList());
                                 AgregarFilaFq(tabla, "Cloruros", fqSamples.Select(m => m.FisicoQuimico?.Cloruros ?? "-").ToList());
                                 AgregarFilaFq(tabla, "Calcio", fqSamples.Select(m => m.FisicoQuimico?.Calcio ?? "-").ToList());
                                 AgregarFilaFq(tabla, "Magnesio", fqSamples.Select(m => m.FisicoQuimico?.Magnesio ?? "-").ToList());

--- a/Domain/Entities/FisicoQuimico.cs
+++ b/Domain/Entities/FisicoQuimico.cs
@@ -8,7 +8,9 @@
         public string? Turbidez { get; set; }
         public string? Alcalinidad { get; set; }
         public string? Dureza { get; set; }
-        public string? Nitritos { get; set; }       
+        public string? Nitritos { get; set; }
+        public string? Nitratos { get; set; }
+        public string? Amonio { get; set; }
         public string? Cloruros { get; set; }
         public string? Calcio { get; set; }
         public string? Magnesio { get; set; }

--- a/Infrastructure/Dtos/FisicoQuimicoDto.cs
+++ b/Infrastructure/Dtos/FisicoQuimicoDto.cs
@@ -12,6 +12,8 @@ namespace Infrastructure.Dtos
         public string? Alcalinidad { get; set; }
         public string? Dureza { get; set; }
         public string? Nitritos { get; set; }
+        public string? Nitratos { get; set; }
+        public string? Amonio { get; set; }
         public string? Cloruros { get; set; }
         public string? Calcio { get; set; }
         public string? Magnesio { get; set; }

--- a/Infrastructure/Dtos/FisicoQuimicoEditDto.cs
+++ b/Infrastructure/Dtos/FisicoQuimicoEditDto.cs
@@ -11,6 +11,8 @@ namespace Infrastructure.Dtos
  public string? Alcalinidad { get; set; }
  public string? Dureza { get; set; }
  public string? Nitritos { get; set; }
+ public string? Nitratos { get; set; }
+ public string? Amonio { get; set; }
  public string? Cloruros { get; set; }
  public string? Calcio { get; set; }
  public string? Magnesio { get; set; }

--- a/Infrastructure/Migrations/20260505130412_AddFisicoQuimicoAmonioNitratos.Designer.cs
+++ b/Infrastructure/Migrations/20260505130412_AddFisicoQuimicoAmonioNitratos.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infraestructura.Migrations
 {
     [DbContext(typeof(LabAguaDbContext))]
-    partial class LabAguaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505130412_AddFisicoQuimicoAmonioNitratos")]
+    partial class AddFisicoQuimicoAmonioNitratos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.16");

--- a/Infrastructure/Migrations/20260505130412_AddFisicoQuimicoAmonioNitratos.cs
+++ b/Infrastructure/Migrations/20260505130412_AddFisicoQuimicoAmonioNitratos.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infraestructura.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFisicoQuimicoAmonioNitratos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Amonio",
+                table: "BaseEntities",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Nitratos",
+                table: "BaseEntities",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Amonio",
+                table: "BaseEntities");
+
+            migrationBuilder.DropColumn(
+                name: "Nitratos",
+                table: "BaseEntities");
+        }
+    }
+}


### PR DESCRIPTION
Agrega campos Amonio y Nitratos a la entidad FisicoQuimico con migration EF. Campos presentes en DTOs, mapper, factory y reporte de libro de entrada.