### PR TITLE
fix: muestras nuevas no se guardaban al editar libro de entrada

### DIFF
--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -165,7 +165,7 @@ public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync
                 foreach (var muestra in libroEntrada.Muestras)
                 {
                     var existingMuestra = existing.Muestras
-                        .FirstOrDefault(m => m.Id == muestra.Id && m.Id != 0);
+                        .FirstOrDefault(m => m.Id == muestra.Id && muestra.Id > 0);
 
                     if (existingMuestra == null)
                     {
@@ -175,6 +175,12 @@ public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync
                     else
                     {
                         _context.Entry(existingMuestra).CurrentValues.SetValues(muestra);
+
+                        // Sincronizar análisis si la muestra existente no lo tenía aún
+                        if (muestra.Bacteriologia != null && existingMuestra.Bacteriologia == null)
+                            existingMuestra.Bacteriologia = muestra.Bacteriologia;
+                        if (muestra.FisicoQuimico != null && existingMuestra.FisicoQuimico == null)
+                            existingMuestra.FisicoQuimico = muestra.FisicoQuimico;
                     }
                 }
             }

--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -160,6 +160,23 @@ public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync
             if (existing != null)
             {
                 _context.Entry(existing).CurrentValues.SetValues(libroEntrada);
+
+                // Sincronizar muestras: actualizar existentes y agregar nuevas (Id == 0)
+                foreach (var muestra in libroEntrada.Muestras)
+                {
+                    var existingMuestra = existing.Muestras
+                        .FirstOrDefault(m => m.Id == muestra.Id && m.Id != 0);
+
+                    if (existingMuestra == null)
+                    {
+                        // Muestra nueva: agregar a la colección trackeada → EF la insertará
+                        existing.Muestras.Add(muestra);
+                    }
+                    else
+                    {
+                        _context.Entry(existingMuestra).CurrentValues.SetValues(muestra);
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
Bug: UpdateAsync en LibroDeEntradaRepository usaba CurrentValues.SetValues() que solo copia propiedades escalares, ignorando la coleccion Muestras. Las muestras nuevas (Id=0) agregadas por el service nunca se persistian.

Fix:
- Agregar loop de sincronizacion de muestras despues de SetValues
- Muestras con Id>0: actualizar propiedades escalares con SetValues
- Muestras con Id==0: agregar a la coleccion trackeada (EF Core las inserta)
- Bonus: sincronizar navigation properties Bacteriologia/FisicoQuimico si la muestra existente no los tenia