### PR TITLE
fix: reemplazar filtros .Date no sargables por comparacion de rango

### DIFF
--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -105,11 +105,11 @@ public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync
             (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var desdeDate = desde.Date;
-            var hastaDate = hasta.Date;
+            var hastaDate = hasta.Date.AddDays(1);
 
             var query = _context.LibroEntradas
                 .AsNoTracking()
-                .Where(le => le.Fecha.Date >= desdeDate && le.Fecha.Date <= hastaDate)
+                .Where(le => le.Fecha >= desdeDate && le.Fecha < hastaDate)
                 .WithFullMuestras();
 
             var totalCount = await query.CountAsync();

--- a/Infrastructure/Repositories/PlanillaDiariaRepository.cs
+++ b/Infrastructure/Repositories/PlanillaDiariaRepository.cs
@@ -34,13 +34,14 @@ namespace Infrastructure.Repositories
 
         public async Task<PlanillaDiaria?> GetByFechaAsync(DateTime fecha)
         {
-            var fechaSolo = fecha.Date;
+            var fechaDesde = fecha.Date;
+            var fechaHasta = fechaDesde.AddDays(1);
             return await _context.PlanillasDiarias
                 .Include(p => p.EnsayoJarras)
                 .Include(p => p.LibroEntrada)
                     .ThenInclude(le => le!.Muestras)
                         .ThenInclude(m => m.FisicoQuimico)
-                .FirstOrDefaultAsync(p => p.Fecha.Date == fechaSolo);
+                .FirstOrDefaultAsync(p => p.Fecha >= fechaDesde && p.Fecha < fechaHasta);
         }
 
         public async Task<(List<PlanillaDiaria> Items, int TotalCount)> GetAllPagedAsync(int page, int pageSize)
@@ -68,14 +69,14 @@ namespace Infrastructure.Repositories
             (page, pageSize) = PaginationDefaults.Normalize(page, pageSize);
 
             var desdeDate = desde.Date;
-            var hastaDate = hasta.Date;
+            var hastaDate = hasta.Date.AddDays(1);
 
             var query = _context.PlanillasDiarias
                 .Include(p => p.EnsayoJarras)
                 .Include(p => p.LibroEntrada)
                     .ThenInclude(le => le!.Muestras)
                         .ThenInclude(m => m.FisicoQuimico)
-                .Where(p => p.Fecha.Date >= desdeDate && p.Fecha.Date <= hastaDate)
+                .Where(p => p.Fecha >= desdeDate && p.Fecha < hastaDate)
                 .OrderByDescending(p => p.Fecha);
 
             var total = await query.CountAsync();


### PR DESCRIPTION
Closes #25

Reemplaza filtros .Date en queries LINQ de PlanillaDiariaRepository y LibroDeEntradaRepository por comparacion de rango sargable (>= fechaDesde && < fechaHasta). FisicoQuimicoRepository y BacteriologicoRepository ya tenian el patron correcto.