### PR TITLE
fix: eliminar doble query en DeleteAsync de FisicoQuimico y Bacteriologico

### DIFF
--- a/Aplicacion/Services/BacteriologicoService.cs
+++ b/Aplicacion/Services/BacteriologicoService.cs
@@ -89,7 +89,7 @@ namespace Aplicacion.Services
             var entity = await _repo.GetByIdAsync(id);
             if (entity == null)
                 return Result.Failure($"Bacteriologico con ID {id} no encontrado.");
-            await _repo.DeleteAsync(id);
+            await _repo.DeleteAsync(entity);
             return Result.Success();
         }
     }

--- a/Aplicacion/Services/FisicoQuimicoService.cs
+++ b/Aplicacion/Services/FisicoQuimicoService.cs
@@ -92,7 +92,7 @@ namespace Aplicacion.Services
             if (entity == null)
                 return Result.Failure($"FisicoQuimico con ID {id} no encontrado.");
 
-            await _repo.DeleteAsync(id);
+            await _repo.DeleteAsync(entity);
             return Result.Success();
         }
     }

--- a/Domain/IRepository/IRepository.cs
+++ b/Domain/IRepository/IRepository.cs
@@ -48,7 +48,7 @@ namespace Dominio.IRepository
         Task<(List<Bacteriologico> Items, int TotalCount)> GetByClienteIdPagedAsync(int clienteId, int page, int pageSize);
         Task<Bacteriologico?> GetByIdAsync(int id);
         Task UpdateAsync(Bacteriologico bacteriologico);
-        Task DeleteAsync(int id);
+        Task DeleteAsync(Bacteriologico entity);
     }
 
     public interface ILibroFisicoQuimicoRepository
@@ -60,7 +60,7 @@ namespace Dominio.IRepository
         Task<(List<FisicoQuimico> Items, int TotalCount)> GetByClienteIdPagedAsync(int clienteId, int page, int pageSize);
         Task<FisicoQuimico?> GetByIdAsync(int id);
         Task UpdateAsync(FisicoQuimico fisicoQuimico);
-        Task DeleteAsync(int id);
+        Task DeleteAsync(FisicoQuimico entity);
     }
 
     public interface IPlanillaDiariaRepository

--- a/Infrastructure/Repositories/BacteriologicoRepository.cs
+++ b/Infrastructure/Repositories/BacteriologicoRepository.cs
@@ -101,10 +101,8 @@ namespace Infrastructure.Repositories
             await _context.SaveChangesAsync();
         }
 
-        public async Task DeleteAsync(int id)
+        public async Task DeleteAsync(Bacteriologico entity)
         {
-            var entity = await _context.Bacteriologicos.FindAsync(id);
-            if (entity == null) return;
             _context.Bacteriologicos.Remove(entity);
             await _context.SaveChangesAsync();
         }

--- a/Infrastructure/Repositories/FisicoQuimicoRepository.cs
+++ b/Infrastructure/Repositories/FisicoQuimicoRepository.cs
@@ -102,14 +102,10 @@ namespace Infrastructure.Repositories
             await _context.SaveChangesAsync();
         }
 
-        public async Task DeleteAsync(int id)
+        public async Task DeleteAsync(FisicoQuimico entity)
         {
-            var entity = await _context.FisicoQuimicos.FindAsync(id);
-            if (entity != null)
-            {
-                _context.FisicoQuimicos.Remove(entity);
-                await _context.SaveChangesAsync();
-            }
+            _context.FisicoQuimicos.Remove(entity);
+            await _context.SaveChangesAsync();
         }
     }
 }


### PR DESCRIPTION
Closes #24

Cambia la firma de DeleteAsync en ILibroFisicoQuimicoRepository e ILibroBacteriologiaRepository para recibir la entidad ya trackeada en lugar del id. El servicio ya cargaba la entidad para validar existencia; ahora esa misma entidad se pasa al repositorio que llama directamente a Remove(), eliminando el segundo FindAsync interno.