### PR TITLE
fix: estandarizar GetByIdAsync para retornar T? en repositorios

### DIFF
--- a/Domain/IRepository/IRepository.cs
+++ b/Domain/IRepository/IRepository.cs
@@ -5,7 +5,7 @@ namespace Dominio.IRepository
     public interface IClienteRepository
     {
         Task<Cliente> AddAsync(Cliente cliente);
-        Task<Cliente> GetByIdAsync(int id);       
+        Task<Cliente?> GetByIdAsync(int id);       
         Task<List<Cliente>> GetAllAsync();
         Task UpdateAsync(Cliente cliente);
         Task DeleteAsync(int id);
@@ -14,7 +14,7 @@ namespace Dominio.IRepository
     public interface IMuestraRepository
     {
         Task<Muestra> AddAsync(Muestra muestra);
-        Task<Muestra> GetByIdAsync(int id);
+        Task<Muestra?> GetByIdAsync(int id);
         Task<List<Muestra>> GetByClienteIdAsync(int clienteId); // Nuevo método
         Task DeleteAsync(int id);
     }

--- a/Infrastructure/Repositories/ClienteRepository.cs
+++ b/Infrastructure/Repositories/ClienteRepository.cs
@@ -21,7 +21,7 @@ namespace Infrastructure.Repositories
             return cliente;
         }
 
-        public async Task<Cliente> GetByIdAsync(int id)
+        public async Task<Cliente?> GetByIdAsync(int id)
         {
             return await _context.Clientes
                 .AsNoTracking()

--- a/Infrastructure/Repositories/MuestraRepository.cs
+++ b/Infrastructure/Repositories/MuestraRepository.cs
@@ -51,7 +51,7 @@ namespace Infrastructure.Repositories
               .ToListAsync();
         }
 
-        public async Task<Muestra> GetByIdAsync(int id)
+        public async Task<Muestra?> GetByIdAsync(int id)
         {
             return await _context.Muestras
             .Include(m => m.Cliente)


### PR DESCRIPTION
## Cambios
- `IClienteRepository.GetByIdAsync` ahora retorna `Task<Cliente?>`
- `IMuestraRepository.GetByIdAsync` ahora retorna `Task<Muestra?>`
- `ClienteRepository` y `MuestraRepository` implementan el tipo nullable correctamente

## Motivación
Eliminar discrepancia entre el tipo de retorno declarado y el valor real (`FirstOrDefaultAsync` puede retornar `null`).

Closes #19