### PR TITLE
feat: reporte PDF múltiple de libros de entrada (#135)

### DIFF
--- a/ApiLaboratorioAgua/Controllers/LibroEntradaController.cs
+++ b/ApiLaboratorioAgua/Controllers/LibroEntradaController.cs
@@ -123,5 +123,15 @@ namespace ApiLaboratorioAgua.Controllers
             var pdfBytes = await _reporteService.GenerarPdfBytesAsync(id);
             return File(pdfBytes, "application/pdf", $"reporte_libro_{id}.pdf");
         }
+
+        [HttpPost("reporte-multiple")]
+        public async Task<IActionResult> GetReporteMultiplePdf([FromBody] ReporteMultipleRequestDto request)
+        {
+            if (request.LibroIds == null || request.LibroIds.Count == 0)
+                return BadRequest("Debe proporcionar al menos un ID de libro de entrada.");
+
+            var pdfBytes = await _reporteService.GenerarPdfMultipleBytesAsync(request.LibroIds);
+            return File(pdfBytes, "application/pdf", "reporte_multiple_libros.pdf");
+        }
     }
 }

--- a/Aplicacion/Services/ReporteService.cs
+++ b/Aplicacion/Services/ReporteService.cs
@@ -31,6 +31,36 @@ namespace Aplicacion.Services
             return GeneratePdfBytes(reporte);
         }
 
+        public async Task<List<ReporteResumenLibroDto>> GenerarReporteMultipleAsync(List<int> libroIds)
+        {
+            var libros = await _libroEntradaRepository.GetByIdsAsync(libroIds);
+            if (libros.Count == 0)
+                throw new NotFoundException("Ningún libro de entrada encontrado con los IDs proporcionados.");
+
+            return libros.Select(libro =>
+            {
+                var tipos = libro.Muestras?
+                    .Select(m => m.TipoMuestra == Dominio.Entities.TipoMuestra.Bacteriologica ? "Bacteriológica" : "Fisicoquímica")
+                    .Distinct()
+                    .OrderBy(t => t)
+                    .ToList() ?? new List<string>();
+
+                return new ReporteResumenLibroDto
+                {
+                    LibroId = libro.Id,
+                    FechaAnalisis = libro.FechaAnalisis,
+                    Procedencia = libro.Procedencia,
+                    TiposAnalisis = tipos
+                };
+            }).ToList();
+        }
+
+        public async Task<byte[]> GenerarPdfMultipleBytesAsync(List<int> libroIds)
+        {
+            var reportes = await GenerarReporteMultipleAsync(libroIds);
+            return GeneratePdfMultipleBytes(reportes);
+        }
+
         private static byte[] GeneratePdfBytes(ReporteLibroDto reporte)
         {
             var muestras = reporte.Muestras.ToList();
@@ -153,6 +183,60 @@ namespace Aplicacion.Services
                         if (!bactSamples.Any() && !fqSamples.Any())
                         {
                             col.Item().PaddingTop(20).Text("Sin muestras con resultados.").Italic();
+                        }
+                    });
+
+                    page.Footer().AlignCenter().Text($"Generado: {DateTime.Now:yyyy-MM-dd HH:mm}");
+                });
+            });
+
+            return doc.GeneratePdf();
+        }
+
+        private static byte[] GeneratePdfMultipleBytes(List<ReporteResumenLibroDto> reportes)
+        {
+            var doc = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.A4.Landscape());
+                    page.Margin(20);
+                    page.PageColor(Colors.White);
+                    page.DefaultTextStyle(x => x.FontSize(9));
+
+                    page.Header().Column(h =>
+                    {
+                        h.Item().Text("REPORTE MÚLTIPLE DE LIBROS DE ENTRADA").FontSize(14).Bold().AlignCenter();
+                        h.Item().PaddingBottom(5).Text($"Total de libros seleccionados: {reportes.Count}").FontSize(10).AlignCenter();
+                    });
+
+                    page.Content().Table(tabla =>
+                    {
+                        tabla.ColumnsDefinition(c =>
+                        {
+                            c.ConstantColumn(40);
+                            c.ConstantColumn(120);
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                        });
+
+                        tabla.Cell().ColumnSpan(4).Background(Colors.Grey.Lighten3).Padding(5)
+                            .Text("RESUMEN").Bold().FontSize(10);
+
+                        tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("#").Bold().FontSize(8);
+                        tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("Fecha Análisis").Bold().FontSize(8);
+                        tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("Procedencia").Bold().FontSize(8);
+                        tabla.Cell().Background(Colors.Grey.Lighten1).Padding(3).Text("Tipo(s) de Análisis").Bold().FontSize(8);
+
+                        int index = 1;
+                        foreach (var r in reportes)
+                        {
+                            var bg = index % 2 == 0 ? Colors.Grey.Lighten5 : Colors.White;
+                            tabla.Cell().Background(bg).Padding(3).AlignCenter().Text(index.ToString()).FontSize(8);
+                            tabla.Cell().Background(bg).Padding(3).Text(r.FechaAnalisis?.ToString("yyyy-MM-dd") ?? "-").FontSize(8);
+                            tabla.Cell().Background(bg).Padding(3).Text(r.Procedencia ?? "-").FontSize(8);
+                            tabla.Cell().Background(bg).Padding(3).Text(string.Join(", ", r.TiposAnalisis)).FontSize(8);
+                            index++;
                         }
                     });
 

--- a/Domain/IRepository/IRepository.cs
+++ b/Domain/IRepository/IRepository.cs
@@ -37,6 +37,7 @@ namespace Dominio.IRepository
         Task<(List<LibroDeEntrada> Items, int TotalCount)> GetByFechaRangoPagedAsync(DateTime desde, DateTime hasta, int page, int pageSize);
         Task<List<LibroDeEntrada>> GetByProcedenciaAsync(string procedencia);
         Task<List<LibroDeEntrada>> GetByMuestraIdAsync(int muestraId);
+        Task<List<LibroDeEntrada>> GetByIdsAsync(List<int> ids);
     }
 
     public interface ILibroBacteriologiaRepository

--- a/Infrastructure/Dtos/ReporteDto.cs
+++ b/Infrastructure/Dtos/ReporteDto.cs
@@ -3,6 +3,20 @@ using System.Collections.Generic;
 
 namespace Infrastructure.Dtos
 {
+    public class ReporteMultipleRequestDto
+    {
+        public List<int> LibroIds { get; set; } = new();
+    }
+
+    public class ReporteResumenLibroDto
+    {
+        public int LibroId { get; set; }
+        public DateTime? FechaAnalisis { get; set; }
+        public string? Procedencia { get; set; }
+        public List<string> TiposAnalisis { get; set; } = new();
+    }
+
+
     public class ReporteLibroDto
     {
         public int LibroId { get; set; }

--- a/Infrastructure/Repositories/LibroDeEntradaRepository.cs
+++ b/Infrastructure/Repositories/LibroDeEntradaRepository.cs
@@ -148,6 +148,16 @@ public async Task<(List<LibroDeEntrada> Items, int TotalCount)> GetAllPagedAsync
                 .ToListAsync();
         }
 
+        public async Task<List<LibroDeEntrada>> GetByIdsAsync(List<int> ids)
+        {
+            return await _context.LibroEntradas
+                .AsNoTracking()
+                .WithFullMuestras()
+                .Where(le => ids.Contains(le.Id))
+                .OrderByDescending(le => le.Fecha)
+                .ToListAsync();
+        }
+
         public async Task UpdateAsync(LibroDeEntrada libroEntrada)
         {
             var existing = await _context.LibroEntradas


### PR DESCRIPTION
Closes #135

Nuevo endpoint POST /api/LibroEntrada/reporte-multiple que recibe una lista de IDs de libros de entrada y genera un PDF resumen con Fecha de análisis, Procedencia y Tipo(s) de análisis de cada libro seleccionado.

## Cambios

1. **Domain** - ILibroEntradaQueryRepository.GetByIdsAsync(List<int> ids)
2. **Infrastructure** - Implementación en LibroDeEntradaRepository + DTOs ReporteMultipleRequestDto y ReporteResumenLibroDto
3. **Aplicacion** - ReporteService.GenerarPdfMultipleBytesAsync(List<int> ids) y GeneratePdfMultipleBytes()
4. **API** - Endpoint POST /api/LibroEntrada/reporte-multiple

## Diseño del PDF

Tabla resumen: #, Fecha Análisis, Procedencia, Tipo(s) de Análisis. Formato A4 apaisado.